### PR TITLE
Create has_shadow_root.js

### DIFF
--- a/custom_metrics/has_shadow_root.js
+++ b/custom_metrics/has_shadow_root.js
@@ -17,7 +17,7 @@ var allowed = /^(article|aside|blockquote|body|div|footer|h1|h2|h3|h4|h5|h6|head
 
 function isValidCustomElementName(el) {
     // it's got to have a dash
-    if ((el.tagName.indexOf('-') !== -1) {
+    if (el.tagName.indexOf('-') !== -1) {
          // it has to be both an HTMLElement this prevents us from getting
          // any dasherized elements that could exist in 'other embdedded'
         if (el instanceof HTMLElement) {

--- a/custom_metrics/has_shadow_root.js
+++ b/custom_metrics/has_shadow_root.js
@@ -15,7 +15,7 @@
   or not. 
 */
 
-var allowed = /^(article|aside|blockquote|body|div|footer|h1|h2|h3|h4|h5|h6|header||main|nav|p|section|span)$/i
+var allowed = /^(article|aside|blockquote|body|div|footer|h1|h2|h3|h4|h5|h6|header|main|nav|p|section|span)$/i
 
 function isValidCustomElementName(el) {
     return (el.tagName.indexOf('-') !== -1 && !(el instanceof HTMLUnknownElement))
@@ -33,5 +33,5 @@ function hasAuthorShadowRoot(el) {
     )
 }
 
-return Array.from(document.querySelectorAll('*'))
+return "" + Array.from(document.querySelectorAll('*'))
             .some(hasAuthorShadowRoot)

--- a/custom_metrics/has_shadow_root.js
+++ b/custom_metrics/has_shadow_root.js
@@ -11,14 +11,22 @@
   
   (see https://dom.spec.whatwg.org/#dom-element-attachshadow)
   Since we are using the parsed DOM, we can simplify the second part a little 
-  by simply checking for a dash and then whether it parsed as HTMLUnknownElement 
-  or not. 
 */
 
 var allowed = /^(article|aside|blockquote|body|div|footer|h1|h2|h3|h4|h5|h6|header|main|nav|p|section|span)$/i
 
 function isValidCustomElementName(el) {
-    return (el.tagName.indexOf('-') !== -1 && !(el instanceof HTMLUnknownElement))
+    // it's got to have a dash
+    if ((el.tagName.indexOf('-') !== -1) {
+         // it has to be both an HTMLElement this prevents us from getting
+         // any dasherized elements that could exist in 'other embdedded'
+        if (el instanceof HTMLElement) {
+
+             // finally, it actually has to be defined as a custom element
+             return !(el instanceof HTMLUnknownElement)
+        }
+    }
+    return false
 }
 
 function hasAuthorShadowRoot(el) {

--- a/custom_metrics/has_shadow_root.js
+++ b/custom_metrics/has_shadow_root.js
@@ -1,0 +1,37 @@
+
+/* 
+  What we're looking for here is elements with non-native, 
+  author-created shadow roots.
+
+  ShadowRoots can be author-created on either 
+  
+  * the elements specifically in the allowed list 
+  
+  * on things parsed with valid custom element name productions. 
+  
+  (see https://dom.spec.whatwg.org/#dom-element-attachshadow)
+  Since we are using the parsed DOM, we can simplify the second part a little 
+  by simply checking for a dash and then whether it parsed as HTMLUnknownElement 
+  or not. 
+*/
+
+var allowed = /^(article|aside|blockquote|body|div|footer|h1|h2|h3|h4|h5|h6|header||main|nav|p|section|span)$/i
+
+function isValidCustomElementName(el) {
+    return (el.tagName.indexOf('-') !== -1 && !(el instanceof HTMLUnknownElement))
+}
+
+function hasAuthorShadowRoot(el) {
+    return (
+        (
+            isValidCustomElementName(el) 
+            || 
+            allowed.test(el.tagName)
+        ) 
+        && 
+        el.shadowRoot
+    )
+}
+
+return Array.from(document.querySelectorAll('*'))
+            .some(hasAuthorShadowRoot)


### PR DESCRIPTION
per https://github.com/HTTPArchive/httparchive.org/issues/141 - this is slightly complicated by the fact that I think we don't want to include native elements that have a shadow root like inputs and video in this, so... someone should probably review this to see if it makes sense.