### PR TITLE
Add custom metric for 12.11

### DIFF
--- a/custom_metrics/almanac.js
+++ b/custom_metrics/almanac.js
@@ -247,5 +247,22 @@ return JSON.stringify({
       }
     }
     return 0;
+  })(),
+  '12.11': (() => {
+    // Counts the links or buttons only containing an icon.
+    var clickables = document.querySelectorAll('a, button');
+    return Array.from(clickables).reduce((n, clickable) => {
+      // Clickables containing SVG are assumed to be icons.
+      if (clickable.firstElementChild && clickable.firstElementChild.tagName == 'SVG') {
+        return n + 1;
+      }
+      // Clickables containing 1-char text are assumed to be icons.
+      // Note that this fails spectacularly for complex unicode points.
+      // See https://blog.jonnew.com/posts/poo-dot-length-equals-two.
+      if (clickable.textContent.trim().length == 1) {
+        return n + 1;
+      }
+      return n;
+    }, 0);
   })()
 });


### PR DESCRIPTION
https://www.webpagetest.org/custom_metrics.php?test=190628_4K_a646aef9fe95cc2fa5b2159d79662cea&run=1&cached=0

Progress on https://github.com/HTTPArchive/almanac.httparchive.org/issues/33

Counts the links or buttons only containing an icon.