### PR TITLE
Almanac custom metrics

### DIFF
--- a/custom_metrics/almanac.js
+++ b/custom_metrics/almanac.js
@@ -11,12 +11,22 @@
 // 3. Test your change by following the instructions at https://github.com/HTTPArchive/almanac.httparchive.org/issues/33#issuecomment-502288773.
 // 4. Submit a PR to update this file.
 
+// Sanitize the `attributes` property.
+function getNodeAttributes(node) {
+  // Inspired by dequelabs/axe-core.
+  if (node.attributes instanceof NamedNodeMap) {
+    return node.attributes;
+  }
+  return node.cloneNode(false).attributes;
+}
+
+// Map nodes to their attributes,
 function parseNodes(nodes) {
   var parsedNodes = [];
   if (nodes) {
     for (var i = 0, len = nodes.length; i < len; i++) {
       var node = nodes[i];
-      var attributes = Object.values(node.attributes);
+      var attributes = Object.values(getNodeAttributes(node));
       var el = {};
 
       el.tagName = node.tagName.toLowerCase(); // for reference
@@ -255,6 +265,14 @@ return JSON.stringify({
       'script': document.querySelectorAll('script[integrity]').length
     };
   })(),
+  '09.27': (() => {
+    // Returns a JSON array of nodes with a tabindex and their key/value attributes.
+    // We acknowledge that attribute selectors are expensive to query.
+    var nodes = document.querySelectorAll('body [tabindex]');
+    var parsedNodes = parseNodes(nodes);
+
+    return parsedNodes;
+  })(),
   '12.11': (() => {
     // Counts the links or buttons only containing an icon.
     var clickables = document.querySelectorAll('a, button');
@@ -274,6 +292,7 @@ return JSON.stringify({
   })(),
   'amp-plugin': (() => {
     // Gets metadata about the AMP plugin, if present.
+    // Used by 14.2, 14.3, 14.4.
     try {
       var r = new RegExp("^AMP Plugin v(\\d+\\.\\d+.*?)(?:;\\s*mode=(\\w+))?(?:;\\s*experiences=(\\w+))?$");
       var metadata = Array.from(document.querySelectorAll('meta[name=generator][content^="AMP Plugin"]')).filter(e => r.test(e.content)).map(e => r.exec(e.content))[0];

--- a/custom_metrics/almanac.js
+++ b/custom_metrics/almanac.js
@@ -271,5 +271,20 @@ return JSON.stringify({
       }
       return n;
     }, 0);
+  })(),
+  'amp-plugin': (() => {
+    // Gets metadata about the AMP plugin, if present.
+    try {
+      var r = new RegExp("^AMP Plugin v(\\d+\\.\\d+.*?)(?:;\\s*mode=(\\w+))?(?:;\\s*experiences=(\\w+))?$");
+      var metadata = Array.from(document.querySelectorAll('meta[name=generator][content^="AMP Plugin"]')).filter(e => r.test(e.content)).map(e => r.exec(e.content))[0];
+      if (metadata) {
+        return {
+          'version': metadata[1],
+          'mode': metadata[2],
+          'experiences': metadata[3]
+        };
+      }
+    } catch (e) {}
+    return null;
   })()
 });

--- a/custom_metrics/almanac.js
+++ b/custom_metrics/almanac.js
@@ -248,6 +248,13 @@ return JSON.stringify({
     }
     return 0;
   })(),
+  '08.39': (() => {
+    // Counts the number of link/script elements with the subresource integrity attribute.
+    return {
+      'link': document.querySelectorAll('link[integrity]').length,
+      'script': document.querySelectorAll('script[integrity]').length
+    };
+  })(),
   '12.11': (() => {
     // Counts the links or buttons only containing an icon.
     var clickables = document.querySelectorAll('a, button');


### PR DESCRIPTION
Progress on https://github.com/HTTPArchive/almanac.httparchive.org/issues/33

Addresses metrics 08.39 (SRI) and 14.2-4 (AMP plugin)

https://www.webpagetest.org/custom_metrics.php?test=190628_4V_06eaa519ab5251a4a8c2073cd72c2dc8&run=1&cached=0
https://www.webpagetest.org/custom_metrics.php?test=190628_P1_51f3807c082e4f5a7b5c7092ec22576f&run=1&cached=0
https://www.webpagetest.org/custom_metrics.php?test=190628_B5_4c6fca755c6ce2756756b1d04d6d38b7&run=1&cached=0
https://www.webpagetest.org/custom_metrics.php?test=190629_X7_2fe55c5f5415b83101648c2d86200055&run=1&cached=0