### PR TITLE
earlyHash custom metric

### DIFF
--- a/custom_metrics/almanac.js
+++ b/custom_metrics/almanac.js
@@ -135,6 +135,7 @@ return JSON.stringify({
     var external = 0; // metric 10.10
     var hash = 0;
     var navigateHash = 0; // metric 10.11
+    var earlyHash = 0; // metric 09.10
 
     if (nodes) {
       for (var i = 0, len = nodes.length; i < len; i++) {
@@ -152,6 +153,9 @@ return JSON.stringify({
                 var element = document.querySelector(link.hash);
                 if (element) {
                   hash++;
+                  if (i < 3) {
+                    earlyHash++;
+                  }
                 } else {
                   navigateHash++;
                 }
@@ -164,7 +168,7 @@ return JSON.stringify({
       }
     }
 
-    return { internal, external, hash, navigateHash };
+    return { internal, external, hash, navigateHash, earlyHash };
   })(),
   // Extracts titles used and counts the words, to flag thin content pages
   'seo-titles': (() => {


### PR DESCRIPTION
Progress on https://github.com/HTTPArchive/almanac.httparchive.org/issues/33

https://www.webpagetest.org/custom_metrics.php?test=190630_RH_feb05f7887f923ad6d9e5f9bce25426b&run=1&cached=0

Wow, I was surprised that this actually caught the NYT website doing the desired behavior. `earlyHash` is 2 in this test.

Default view, anchors hidden until focused:
![image](https://user-images.githubusercontent.com/1120896/60397247-cd749200-9b18-11e9-8c2a-d8e6511743cd.png)

-----

Tabbing to the first anchor on the page make this become visible:
![image](https://user-images.githubusercontent.com/1120896/60397250-d36a7300-9b18-11e9-84ae-baeb072f1e3d.png)

------

Second anchor:
![image](https://user-images.githubusercontent.com/1120896/60397254-d82f2700-9b18-11e9-9883-975cfff40818.png)
