### PR TITLE
 added custom metric for media chapter - picture tag containing img

### DIFF
--- a/custom_metrics/almanac.js
+++ b/custom_metrics/almanac.js
@@ -307,5 +307,5 @@ return JSON.stringify({
     }
   })(),
   //  check if there is any picture tag containing an img tag
-  'has_picture_img': document.querySelectorAll("picture img").length > 0
+  'has_picture_img': document.querySelectorAll('picture img').length > 0
 });

--- a/custom_metrics/almanac.js
+++ b/custom_metrics/almanac.js
@@ -305,5 +305,6 @@ return JSON.stringify({
     } catch (e) {
       return null;
     }
-  })()
+  })(),
+  'has_picture_img': document.querySelectorAll("picture img").length > 0
 });

--- a/custom_metrics/almanac.js
+++ b/custom_metrics/almanac.js
@@ -306,5 +306,6 @@ return JSON.stringify({
       return null;
     }
   })(),
+  //  check if there is any picturen tag containing an img tag
   'has_picture_img': document.querySelectorAll("picture img").length > 0
 });

--- a/custom_metrics/almanac.js
+++ b/custom_metrics/almanac.js
@@ -306,6 +306,6 @@ return JSON.stringify({
       return null;
     }
   })(),
-  //  check if there is any picturen tag containing an img tag
+  //  check if there is any picture tag containing an img tag
   'has_picture_img': document.querySelectorAll("picture img").length > 0
 });


### PR DESCRIPTION
As @rviscomi commented for the [2020 media chapter](https://github.com/HTTPArchive/almanac.httparchive.org/issues/900#issuecomment-660275165), some sql queries are expensive because they search in response bodies using regexp contains

[picture img sql](https://github.com/HTTPArchive/almanac.httparchive.org/blob/2189e7b3d80b94a09c9a1c59926ea63b3fe17c34/sql/2019/04_Media/04_08.sql)

I have tried to add a custom metric in almanac.js. I do not know if the notation used by me is according to your standards (If the value requires more than one line of code,...). Please advise.