### PR TITLE
Custom metrics for Media

### DIFF
--- a/custom_metrics/almanac.js
+++ b/custom_metrics/almanac.js
@@ -43,19 +43,17 @@ function parseNodes(nodes) {
 
 // Return the set of attributes for nodes,
 function getNodesAttributes(nodes) {
-  var object = {};
-  if (nodes) {
-    for (var i = 0, len = nodes.length; i < len; i++) {
-      var node = nodes[i];
-      var attributes = Object.values(getNodeAttributes(node));
-
-      for (var n = 0, len2 = attributes.length; n < len2; n++) {
-        var attribute = attributes[n];
-        object[attribute.name.toLowerCase()] = '';
-      }
+  if (!nodes) {
+    return [];
+  }
+  var uniqueAttributes = new Set();
+  for (var node of nodes) {
+    var attributes = Object.values(getNodeAttributes(node));
+    for (var attribute of attributes) {
+      uniqueAttributes.add(attribute.name.toLowerCase());
     }
   }
-  return Object.getOwnPropertyNames(object);
+  return Array.from(uniqueAttributes);
 }
 
 // Return the set of unique parent nodes for nodes

--- a/custom_metrics/almanac.js
+++ b/custom_metrics/almanac.js
@@ -306,8 +306,8 @@ return JSON.stringify({
       return null;
     }
   })(),
-  //  check if there is any picture tag containing an img tag
-  'has_picture_img': document.querySelectorAll('picture img').length > 0,
-  // check if there are any source or img tags with sizes attribute
-  'has_image_sizes': document.querySelectorAll('source[sizes], img[sizes]').length > 0  
+  //  Counts the number of picture tags containing an img tag
+  'num_picture_img': document.querySelectorAll('picture img').length,
+  // Counts the number of source or img tags with sizes attribute
+  'num_image_sizes': document.querySelectorAll('source[sizes], img[sizes]').length
 });

--- a/custom_metrics/almanac.js
+++ b/custom_metrics/almanac.js
@@ -332,9 +332,9 @@ return JSON.stringify({
   // Count the mumber of images with srcset and sizes attributes
   'num_srcset_sizes': document.querySelectorAll('source[srcset][sizes], img[srcset][sizes]').length,
   // Count the number of imges with srcset with descriptor-x
-  'num_srcset_descriptor-x': document.querySelectorAll('source[srcset*="x"], img[srcset*="x"]').length,
+  'num_srcset_descriptor_x': document.querySelectorAll('source[srcset*="x"], img[srcset*="x"]').length,
   // Count the number of imges with srcset with descriptor-w
-  'num_srcset_descriptor-w': document.querySelectorAll('source[srcset*="w"], img[srcset*="w"]').length,
+  'num_srcset_descriptor_w': document.querySelectorAll('source[srcset*="w"], img[srcset*="w"]').length,
   // Returns a set of video node attribute names
   'video-nodes-attributes': (() => {
     var allAttributes = getNodesAttributes(document.querySelectorAll('video'));

--- a/custom_metrics/almanac.js
+++ b/custom_metrics/almanac.js
@@ -361,11 +361,11 @@ return JSON.stringify({
   // Return picture formats ["image/webp","image/svg+xml"]
   'picture_formats': (() => {
     var nodes = document.querySelectorAll('picture source[type]');
-    var formats = [];
+    var formats = {};
     for (var i = 0, len = nodes.length; i < len; i++) {
-      formats.push(nodes[i]['type'].toLowerCase());
+      formats[nodes[i]['type'].toLowerCase()] = '';
     }
-    return formats;
+    return Object.getOwnPropertyNames(formats);
   })(),
   // Count all video nodes
   'num_video_nodes': document.querySelectorAll('video').length,

--- a/custom_metrics/almanac.js
+++ b/custom_metrics/almanac.js
@@ -41,6 +41,23 @@ function parseNodes(nodes) {
   return parsedNodes;
 }
 
+// Return the set of attributes for nodes,
+function getNodesAttributes(nodes) {
+  var object = {};
+  if (nodes) {
+    for (var i = 0, len = nodes.length; i < len; i++) {
+      var node = nodes[i];
+      var attributes = Object.values(getNodeAttributes(node));
+
+      for (var n = 0, len2 = attributes.length; n < len2; n++) {
+        var attribute = attributes[n];
+        object[attribute.name.toLowerCase()] = '';
+      }
+    }
+  }
+  return Object.getOwnPropertyNames(object);
+}
+
 return JSON.stringify({
   // Wether the page contains <script type=module>.
   '01.12': document.querySelector('script[type=module]') ? 1 : 0,
@@ -309,5 +326,16 @@ return JSON.stringify({
   //  Counts the number of picture tags containing an img tag
   'num_picture_img': document.querySelectorAll('picture img').length,
   // Counts the number of source or img tags with sizes attribute
-  'num_image_sizes': document.querySelectorAll('source[sizes], img[sizes]').length
+  'num_image_sizes': document.querySelectorAll('source[sizes], img[sizes]').length,
+  // Returns a set of video node attribute names
+  'video-nodes-attributes': (() => {
+    var allAttributes = getNodesAttributes(document.querySelectorAll('video'));
+    var filter = ['autoplay', 'autoPictureInPicture', 'buffered', 'controls',
+      'controlslist', 'crossorigin', 'use-credentials', 'currentTime',
+      'disablePictureInPicture', 'disableRemotePlayback', 'duration',
+      'height', 'intrinsicsize', 'loop', 'muted', 'playsinline', 'poster',
+      'preload', 'src', 'width'];
+    // Returns a JSON array of video nodes and their key/value attributes.
+    return allAttributes.filter(el => filter.includes(el));
+  })()
 });

--- a/custom_metrics/almanac.js
+++ b/custom_metrics/almanac.js
@@ -328,9 +328,13 @@ return JSON.stringify({
   // Counts the number of source or img tags with sizes attribute
   'num_image_sizes': document.querySelectorAll('source[sizes], img[sizes]').length,
   // Count the mumber of images with srcset attribute
-  num_srcset_all: document.querySelectorAll('source[srcset], img[srcset]').length,
+  'num_srcset_all': document.querySelectorAll('source[srcset], img[srcset]').length,
   // Count the mumber of images with srcset and sizes attributes
-  num_srcset_sizes: document.querySelectorAll('source[srcset][sizes], img[srcset][sizes]').length,
+  'num_srcset_sizes': document.querySelectorAll('source[srcset][sizes], img[srcset][sizes]').length,
+  // Count the number of imges with srcset with descriptor-x
+  'num_srcset_descriptor-x': document.querySelectorAll('source[srcset*="x"], img[srcset*="x"]').length,
+  // Count the number of imges with srcset with descriptor-w
+  'num_srcset_descriptor-w': document.querySelectorAll('source[srcset*="w"], img[srcset*="w"]').length,
   // Returns a set of video node attribute names
   'video-nodes-attributes': (() => {
     var allAttributes = getNodesAttributes(document.querySelectorAll('video'));

--- a/custom_metrics/almanac.js
+++ b/custom_metrics/almanac.js
@@ -56,19 +56,6 @@ function getNodesAttributes(nodes) {
   return Array.from(uniqueAttributes);
 }
 
-// Return the set of unique parent nodes for nodes
-function countUniqueParents(nodes)
-{
-  var set = [];
-  for (var i = 0, len = nodes.length; i < len; i++) {
-    if (!set.includes(nodes[i].parentNode))
-    {
-      set.push(nodes[i].parentNode);
-    }
-  }
-  return set.length;
-}
-
 return JSON.stringify({
   // Wether the page contains <script type=module>.
   '01.12': document.querySelector('script[type=module]') ? 1 : 0,
@@ -393,7 +380,10 @@ return JSON.stringify({
   })(),
   // Counts the number of pictures using source media orientation
   'num_picture_using_orientation': (() => {
+    var pictures = document.querySelectorAll('picture');
+    return Array.from(pictures).filter(picture => {
+      return picture.querySelector('source[media*="orientation"]');
+    }).length;
     var nodes = document.querySelectorAll('picture source[media*="orientation"]');
-    return countUniqueParents(nodes);
   })()
 });

--- a/custom_metrics/almanac.js
+++ b/custom_metrics/almanac.js
@@ -270,7 +270,7 @@ return JSON.stringify({
     };
   })(),
   '09.27': (() => {
-    // Returns a JSON array of nodes witha tabindex and their key/value attributes.
+    // Returns a JSON array of nodes with a tabindex and their key/value attributes.
     // We acknowledge that attribute selectors are expensive to query.
     var nodes = document.querySelectorAll('body [tabindex]');
     var parsedNodes = parseNodes(nodes);

--- a/custom_metrics/almanac.js
+++ b/custom_metrics/almanac.js
@@ -353,7 +353,10 @@ return JSON.stringify({
     var nodes = document.querySelectorAll('source[srcset], img[srcset]');
     var count = 0;
     for (var i = 0, len = nodes.length; i < len; i++) {
-      var srcset = nodes[i]['srcset'];
+      var srcset = nodes[i].getAttribute('srcset');
+      if (!srcset) {
+        continue;
+      }
       count += srcset.split(',').length;
     }
     return count;

--- a/custom_metrics/almanac.js
+++ b/custom_metrics/almanac.js
@@ -364,11 +364,15 @@ return JSON.stringify({
   // Return picture formats ["image/webp","image/svg+xml"]
   'picture_formats': (() => {
     var nodes = document.querySelectorAll('picture source[type]');
-    var formats = {};
-    for (var i = 0, len = nodes.length; i < len; i++) {
-      formats[nodes[i]['type'].toLowerCase()] = '';
+    var formats = new Set();
+    for (var source of nodes) {
+      var format = source.getAttribute('type');
+      if (!format) {
+        continue;
+      }
+      formats.add(format.toLowerCase());
     }
-    return Object.getOwnPropertyNames(formats);
+    return Array.from(formats);
   })(),
   // Count all video nodes
   'num_video_nodes': document.querySelectorAll('video').length,

--- a/custom_metrics/almanac.js
+++ b/custom_metrics/almanac.js
@@ -335,7 +335,6 @@ return JSON.stringify({
       'disablePictureInPicture', 'disableRemotePlayback', 'duration',
       'height', 'intrinsicsize', 'loop', 'muted', 'playsinline', 'poster',
       'preload', 'src', 'width'];
-    // Returns a JSON array of video nodes and their key/value attributes.
     return allAttributes.filter(el => filter.includes(el));
   })()
 });

--- a/custom_metrics/almanac.js
+++ b/custom_metrics/almanac.js
@@ -367,7 +367,7 @@ return JSON.stringify({
     }
     return formats;
   })(),
-  // Count all vide nodes
+  // Count all video nodes
   'num_video_nodes': document.querySelectorAll('video').length,
   // Returns a set of video node attribute names
   'video_nodes_attributes': (() => {

--- a/custom_metrics/almanac.js
+++ b/custom_metrics/almanac.js
@@ -41,21 +41,6 @@ function parseNodes(nodes) {
   return parsedNodes;
 }
 
-// Return the set of attributes for nodes,
-function getNodesAttributes(nodes) {
-  if (!nodes) {
-    return [];
-  }
-  var uniqueAttributes = new Set();
-  for (var node of nodes) {
-    var attributes = Object.values(getNodeAttributes(node));
-    for (var attribute of attributes) {
-      uniqueAttributes.add(attribute.name.toLowerCase());
-    }
-  }
-  return Array.from(uniqueAttributes);
-}
-
 return JSON.stringify({
   // Wether the page contains <script type=module>.
   '01.12': document.querySelector('script[type=module]') ? 1 : 0,
@@ -285,7 +270,7 @@ return JSON.stringify({
     };
   })(),
   '09.27': (() => {
-    // Returns a JSON array of nodes with a tabindex and their key/value attributes.
+    // Returns a JSON array of nodes with a tabindex and their key/value attributes.
     // We acknowledge that attribute selectors are expensive to query.
     var nodes = document.querySelectorAll('body [tabindex]');
     var parsedNodes = parseNodes(nodes);
@@ -320,75 +305,5 @@ return JSON.stringify({
     } catch (e) {
       return null;
     }
-  })(),
-  // Counts the number of picture tags containing an img tag
-  'num_picture_img': document.querySelectorAll('picture img').length,
-  // Counts the number of source or img tags with sizes attribute
-  'num_image_sizes': document.querySelectorAll('source[sizes], img[sizes]').length,
-  // Count the mumber of images with srcset attribute
-  'num_srcset_all': document.querySelectorAll('source[srcset], img[srcset]').length,
-  // Count the mumber of images with srcset and sizes attributes
-  'num_srcset_sizes': document.querySelectorAll('source[srcset][sizes], img[srcset][sizes]').length,
-  // Count the number of imges with srcset with descriptor-x
-  'num_srcset_descriptor_x': (() => {
-    var nodes = document.querySelectorAll('source[srcset], img[srcset]');
-    return Array.from(nodes).filter(node => node.getAttribute('srcset').match(/\s\d+x/)).length;
-  })(),
-  // Count the number of imges with srcset with descriptor-w
-  'num_srcset_descriptor_w': (() => {
-    var nodes = document.querySelectorAll('source[srcset], img[srcset]');
-    return Array.from(nodes).filter(node => node.getAttribute('srcset').match(/\s\d+w/)).length;
-  })(),
-  // Count the number of scrset candidates
-  'num_srcset_candidates': (() => {
-    var nodes = document.querySelectorAll('source[srcset], img[srcset]');
-    var count = 0;
-    for (var i = 0, len = nodes.length; i < len; i++) {
-      var srcset = nodes[i].getAttribute('srcset');
-      if (!srcset) {
-        continue;
-      }
-      count += srcset.split(',').length;
-    }
-    return count;
-  })(),
-  // Return picture formats ["image/webp","image/svg+xml"]
-  'picture_formats': (() => {
-    var nodes = document.querySelectorAll('picture source[type]');
-    var formats = new Set();
-    for (var source of nodes) {
-      var format = source.getAttribute('type');
-      if (!format) {
-        continue;
-      }
-      formats.add(format.toLowerCase());
-    }
-    return Array.from(formats);
-  })(),
-  // Count all video nodes
-  'num_video_nodes': document.querySelectorAll('video').length,
-  // Returns a set of video node attribute names
-  'video_nodes_attributes': (() => {
-    var allAttributes = getNodesAttributes(document.querySelectorAll('video'));
-    var filter = ['autoplay', 'autoPictureInPicture', 'buffered', 'controls',
-      'controlslist', 'crossorigin', 'use-credentials', 'currentTime',
-      'disablePictureInPicture', 'disableRemotePlayback', 'duration',
-      'height', 'intrinsicsize', 'loop', 'muted', 'playsinline', 'poster',
-      'preload', 'src', 'width'];
-    return allAttributes.filter(el => filter.includes(el));
-  })(),
-  // Counts the number of pictures using source media min-resolution
-  'num_picture_using_min_resolution': (() => {
-    var pictures = document.querySelectorAll('picture');
-    return Array.from(pictures).filter(picture => {
-      return picture.querySelector('source[media*="min-resolution"]');
-    }).length;
-  })(),
-  // Counts the number of pictures using source media orientation
-  'num_picture_using_orientation': (() => {
-    var pictures = document.querySelectorAll('picture');
-    return Array.from(pictures).filter(picture => {
-      return picture.querySelector('source[media*="orientation"]');
-    }).length;
   })()
 });

--- a/custom_metrics/almanac.js
+++ b/custom_metrics/almanac.js
@@ -367,8 +367,10 @@ return JSON.stringify({
     }
     return formats;
   })(),
+  // Count all vide nodes
+  'num_video_nodes': document.querySelectorAll('video').length,
   // Returns a set of video node attribute names
-  'video-nodes-attributes': (() => {
+  'video_nodes_attributes': (() => {
     var allAttributes = getNodesAttributes(document.querySelectorAll('video'));
     var filter = ['autoplay', 'autoPictureInPicture', 'buffered', 'controls',
       'controlslist', 'crossorigin', 'use-credentials', 'currentTime',

--- a/custom_metrics/almanac.js
+++ b/custom_metrics/almanac.js
@@ -307,5 +307,7 @@ return JSON.stringify({
     }
   })(),
   //  check if there is any picture tag containing an img tag
-  'has_picture_img': document.querySelectorAll('picture img').length > 0
+  'has_picture_img': document.querySelectorAll('picture img').length > 0,
+  // check if there are any source or img tags with sizes attribute
+  'has_image_sizes': document.querySelectorAll('source[sizes], img[sizes]').length > 0  
 });

--- a/custom_metrics/almanac.js
+++ b/custom_metrics/almanac.js
@@ -382,7 +382,7 @@ return JSON.stringify({
     var nodes = document.querySelectorAll('picture source[media*="min-resolution"]');
     return countUniqueParents(nodes);
   })(),
-  // Counts the number of pictures using source media min-resolution
+  // Counts the number of pictures using source media orientation
   'num_picture_using_orientation': (() => {
     var nodes = document.querySelectorAll('picture source[media*="orientation"]');
     return countUniqueParents(nodes);

--- a/custom_metrics/almanac.js
+++ b/custom_metrics/almanac.js
@@ -62,8 +62,6 @@ function getNodesAttributes(nodes) {
 function countUniqueParents(nodes)
 {
   var set = [];
-  // the same picture can have multiple sources with min-resolution
-  // create a set with the picture nodes, parents of source
   for (var i = 0, len = nodes.length; i < len; i++) {
     if (!set.includes(nodes[i].parentNode))
     {

--- a/custom_metrics/almanac.js
+++ b/custom_metrics/almanac.js
@@ -390,6 +390,5 @@ return JSON.stringify({
     return Array.from(pictures).filter(picture => {
       return picture.querySelector('source[media*="orientation"]');
     }).length;
-    var nodes = document.querySelectorAll('picture source[media*="orientation"]');
   })()
 });

--- a/custom_metrics/almanac.js
+++ b/custom_metrics/almanac.js
@@ -270,7 +270,7 @@ return JSON.stringify({
     };
   })(),
   '09.27': (() => {
-    // Returns a JSON array of nodes with a tabindex and their key/value attributes.
+    // Returns a JSON array of nodes with a tabindex and their key/value attributes.
     // We acknowledge that attribute selectors are expensive to query.
     var nodes = document.querySelectorAll('body [tabindex]');
     var parsedNodes = parseNodes(nodes);
@@ -305,5 +305,7 @@ return JSON.stringify({
     } catch (e) {
       return null;
     }
-  })()
+  })(),
+  //  check if there is any picture tag containing an img tag
+  'has_picture_img': document.querySelectorAll('picture img').length > 0
 });

--- a/custom_metrics/almanac.js
+++ b/custom_metrics/almanac.js
@@ -270,7 +270,7 @@ return JSON.stringify({
     };
   })(),
   '09.27': (() => {
-    // Returns a JSON array of nodes with a tabindex and their key/value attributes.
+    // Returns a JSON array of nodes with atabindex and their key/value attributes.
     // We acknowledge that attribute selectors are expensive to query.
     var nodes = document.querySelectorAll('body [tabindex]');
     var parsedNodes = parseNodes(nodes);

--- a/custom_metrics/almanac.js
+++ b/custom_metrics/almanac.js
@@ -340,8 +340,7 @@ return JSON.stringify({
     var nodes = document.querySelectorAll('source[srcset], img[srcset]');
     var count = 0;
     for (var i = 0, len = nodes.length; i < len; i++) {
-      var node = nodes[i];
-      var srcset = node['srcset'];
+      var srcset = nodes[i]['srcset'];
       count += srcset.split(',').length;
     }
     return count;

--- a/custom_metrics/almanac.js
+++ b/custom_metrics/almanac.js
@@ -58,6 +58,21 @@ function getNodesAttributes(nodes) {
   return Object.getOwnPropertyNames(object);
 }
 
+// Return the set of unique parent nodes for nodes
+function countUniqueParents(nodes)
+{
+  var set = [];
+  // the same picture can have multiple sources with min-resolution
+  // create a set with the picture nodes, parents of source
+  for (var i = 0, len = nodes.length; i < len; i++) {
+    if (!set.includes(nodes[i].parentNode))
+    {
+      set.push(nodes[i].parentNode);
+    }
+  }
+  return set.length;
+}
+
 return JSON.stringify({
   // Wether the page contains <script type=module>.
   '01.12': document.querySelector('script[type=module]') ? 1 : 0,
@@ -367,14 +382,11 @@ return JSON.stringify({
   // Counts the number of pictures using source media min-resolution
   'num_picture_using_min_resolution': (() => {
     var nodes = document.querySelectorAll('picture source[media*="min-resolution"]');
-    var set = [];
-    // the same picture can have multiple sources with min-resolution
-    // create a set with the picture nodes, parents of source
-    for (var i = 0, len = nodes.length; i < len; i++) {
-      if (!set.includes(nodes[i].parentNode)) {
-        set.push(nodes[i].parentNode);
-      }
-    }
-    return set.length;
+    return countUniqueParents(nodes);
+  })(),
+  // Counts the number of pictures using source media min-resolution
+  'num_picture_using_orientation': (() => {
+    var nodes = document.querySelectorAll('picture source[media*="orientation"]');
+    return countUniqueParents(nodes);
   })()
 });

--- a/custom_metrics/almanac.js
+++ b/custom_metrics/almanac.js
@@ -270,7 +270,7 @@ return JSON.stringify({
     };
   })(),
   '09.27': (() => {
-    // Returns a JSON array of nodes with atabindex and their key/value attributes.
+    // Returns a JSON array of nodes with a tabindex and their key/value attributes.
     // We acknowledge that attribute selectors are expensive to query.
     var nodes = document.querySelectorAll('body [tabindex]');
     var parsedNodes = parseNodes(nodes);

--- a/custom_metrics/almanac.js
+++ b/custom_metrics/almanac.js
@@ -330,9 +330,15 @@ return JSON.stringify({
   // Count the mumber of images with srcset and sizes attributes
   'num_srcset_sizes': document.querySelectorAll('source[srcset][sizes], img[srcset][sizes]').length,
   // Count the number of imges with srcset with descriptor-x
-  'num_srcset_descriptor_x': document.querySelectorAll('source[srcset*="x"], img[srcset*="x"]').length,
+  'num_srcset_descriptor_x': (() => {
+    var nodes = document.querySelectorAll('source[srcset], img[srcset]');
+    return Array.from(nodes).filter(node => node.getAttribute('srcset').match(/\s\d+x/)).length;
+  })(),
   // Count the number of imges with srcset with descriptor-w
-  'num_srcset_descriptor_w': document.querySelectorAll('source[srcset*="w"], img[srcset*="w"]').length,
+  'num_srcset_descriptor_w': (() => {
+    var nodes = document.querySelectorAll('source[srcset], img[srcset]');
+    return Array.from(nodes).filter(node => node.getAttribute('srcset').match(/\s\d+w/)).length;
+  })(),
   // Count the number of scrset candidates
   'num_srcset_candidates': (() => {
     var nodes = document.querySelectorAll('source[srcset], img[srcset]');

--- a/custom_metrics/almanac.js
+++ b/custom_metrics/almanac.js
@@ -323,10 +323,14 @@ return JSON.stringify({
       return null;
     }
   })(),
-  //  Counts the number of picture tags containing an img tag
+  // Counts the number of picture tags containing an img tag
   'num_picture_img': document.querySelectorAll('picture img').length,
   // Counts the number of source or img tags with sizes attribute
   'num_image_sizes': document.querySelectorAll('source[sizes], img[sizes]').length,
+  // Count the mumber of images with srcset attribute
+  num_srcset_all: document.querySelectorAll('source[srcset], img[srcset]').length,
+  // Count the mumber of images with srcset and sizes attributes
+  num_srcset_sizes: document.querySelectorAll('source[srcset][sizes], img[srcset][sizes]').length,
   // Returns a set of video node attribute names
   'video-nodes-attributes': (() => {
     var allAttributes = getNodesAttributes(document.querySelectorAll('video'));

--- a/custom_metrics/almanac.js
+++ b/custom_metrics/almanac.js
@@ -270,7 +270,7 @@ return JSON.stringify({
     };
   })(),
   '09.27': (() => {
-    // Returns a JSON array of nodes with a tabindex and their key/value attributes.
+    // Returns a JSON array of nodes witha tabindex and their key/value attributes.
     // We acknowledge that attribute selectors are expensive to query.
     var nodes = document.querySelectorAll('body [tabindex]');
     var parsedNodes = parseNodes(nodes);

--- a/custom_metrics/almanac.js
+++ b/custom_metrics/almanac.js
@@ -335,6 +335,17 @@ return JSON.stringify({
   'num_srcset_descriptor_x': document.querySelectorAll('source[srcset*="x"], img[srcset*="x"]').length,
   // Count the number of imges with srcset with descriptor-w
   'num_srcset_descriptor_w': document.querySelectorAll('source[srcset*="w"], img[srcset*="w"]').length,
+  // Count the number of scrset candidates
+  'num_srcset_candidates': (() => {
+    var nodes = document.querySelectorAll('source[srcset], img[srcset]');
+    var count = 0;
+    for (var i = 0, len = nodes.length; i < len; i++) {
+      var node = nodes[i];
+      var srcset = node['srcset'];
+      count += srcset.split(',').length;
+    }
+    return count;
+  })(),
   // Returns a set of video node attribute names
   'video-nodes-attributes': (() => {
     var allAttributes = getNodesAttributes(document.querySelectorAll('video'));

--- a/custom_metrics/almanac.js
+++ b/custom_metrics/almanac.js
@@ -386,8 +386,10 @@ return JSON.stringify({
   })(),
   // Counts the number of pictures using source media min-resolution
   'num_picture_using_min_resolution': (() => {
-    var nodes = document.querySelectorAll('picture source[media*="min-resolution"]');
-    return countUniqueParents(nodes);
+    var pictures = document.querySelectorAll('picture');
+    return Array.from(pictures).filter(picture => {
+      return picture.querySelector('source[media*="min-resolution"]');
+    }).length;
   })(),
   // Counts the number of pictures using source media orientation
   'num_picture_using_orientation': (() => {

--- a/custom_metrics/almanac.js
+++ b/custom_metrics/almanac.js
@@ -363,5 +363,18 @@ return JSON.stringify({
       'height', 'intrinsicsize', 'loop', 'muted', 'playsinline', 'poster',
       'preload', 'src', 'width'];
     return allAttributes.filter(el => filter.includes(el));
+  })(),
+  // Counts the number of pictures using source media min-resolution
+  'num_picture_using_min_resolution': (() => {
+    var nodes = document.querySelectorAll('picture source[media*="min-resolution"]');
+    var set = [];
+    // the same picture can have multiple sources with min-resolution
+    // create a set with the picture nodes, parents of source
+    for (var i = 0, len = nodes.length; i < len; i++) {
+      if (!set.includes(nodes[i].parentNode)) {
+        set.push(nodes[i].parentNode);
+      }
+    }
+    return set.length;
   })()
 });

--- a/custom_metrics/almanac.js
+++ b/custom_metrics/almanac.js
@@ -345,6 +345,15 @@ return JSON.stringify({
     }
     return count;
   })(),
+  // Return picture formats ["image/webp","image/svg+xml"]
+  'picture_formats': (() => {
+    var nodes = document.querySelectorAll('picture source[type]');
+    var formats = [];
+    for (var i = 0, len = nodes.length; i < len; i++) {
+      formats.push(nodes[i]['type'].toLowerCase());
+    }
+    return formats;
+  })(),
   // Returns a set of video node attribute names
   'video-nodes-attributes': (() => {
     var allAttributes = getNodesAttributes(document.querySelectorAll('video'));

--- a/custom_metrics/media.js
+++ b/custom_metrics/media.js
@@ -1,0 +1,120 @@
+//[media]
+// Uncomment the previous line for testing on webpagetest.org
+
+// Sanitize the `attributes` property.
+function getNodeAttributes(node) {
+  // Inspired by dequelabs/axe-core.
+  if (node.attributes instanceof NamedNodeMap) {
+    return node.attributes;
+  }
+  return node.cloneNode(false).attributes;
+}
+
+// Map nodes to their attributes,
+function parseNodes(nodes) {
+  var parsedNodes = [];
+  if (nodes) {
+    for (var i = 0, len = nodes.length; i < len; i++) {
+      var node = nodes[i];
+      var attributes = Object.values(getNodeAttributes(node));
+      var el = {};
+
+      el.tagName = node.tagName.toLowerCase(); // for reference
+      for (var n = 0, len2 = attributes.length; n < len2; n++) {
+        var attribute = attributes[n];
+        el[attribute.name.toLowerCase()] = attribute.value;
+      }
+
+      parsedNodes.push(el);
+    }
+  }
+  return parsedNodes;
+}
+
+// Return the set of attributes for nodes,
+function getNodesAttributes(nodes) {
+  if (!nodes) {
+    return [];
+  }
+  var uniqueAttributes = new Set();
+  for (var node of nodes) {
+    var attributes = Object.values(getNodeAttributes(node));
+    for (var attribute of attributes) {
+      uniqueAttributes.add(attribute.name.toLowerCase());
+    }
+  }
+  return Array.from(uniqueAttributes);
+}
+
+return JSON.stringify({
+  // Counts the number of picture tags containing an img tag
+  'num_picture_img': document.querySelectorAll('picture img').length,
+  // Counts the number of source or img tags with sizes attribute
+  'num_image_sizes': document.querySelectorAll('source[sizes], img[sizes]').length,
+  // Count the mumber of images with srcset attribute
+  'num_srcset_all': document.querySelectorAll('source[srcset], img[srcset]').length,
+  // Count the mumber of images with srcset and sizes attributes
+  'num_srcset_sizes': document.querySelectorAll('source[srcset][sizes], img[srcset][sizes]').length,
+  // Count the number of imges with srcset with descriptor-x
+  'num_srcset_descriptor_x': (() => {
+    var nodes = document.querySelectorAll('source[srcset], img[srcset]');
+    return Array.from(nodes).filter(node => node.getAttribute('srcset').match(/\s\d+x/)).length;
+  })(),
+  // Count the number of imges with srcset with descriptor-w
+  'num_srcset_descriptor_w': (() => {
+    var nodes = document.querySelectorAll('source[srcset], img[srcset]');
+    return Array.from(nodes).filter(node => node.getAttribute('srcset').match(/\s\d+w/)).length;
+  })(),
+  // Count the number of scrset candidates
+  'num_srcset_candidates': (() => {
+    var nodes = document.querySelectorAll('source[srcset], img[srcset]');
+    var count = 0;
+    for (var i = 0, len = nodes.length; i < len; i++) {
+      var srcset = nodes[i].getAttribute('srcset');
+      if (!srcset) {
+        continue;
+      }
+      count += srcset.split(',').length;
+    }
+    return count;
+  })(),
+  // Return picture formats ["image/webp","image/svg+xml"]
+  'picture_formats': (() => {
+    var nodes = document.querySelectorAll('picture source[type]');
+    var formats = new Set();
+    for (var source of nodes) {
+      var format = source.getAttribute('type');
+      if (!format) {
+        continue;
+      }
+      formats.add(format.toLowerCase());
+    }
+    return Array.from(formats);
+  })(),
+  // Count all video nodes
+  'num_video_nodes': document.querySelectorAll('video').length,
+  // Returns a set of video node attribute names
+  'video_nodes_attributes': (() => {
+    var allAttributes = getNodesAttributes(document.querySelectorAll('video'));
+    var filter = ['autoplay', 'autoPictureInPicture', 'buffered', 'controls',
+      'controlslist', 'crossorigin', 'use-credentials', 'currentTime',
+      'disablePictureInPicture', 'disableRemotePlayback', 'duration',
+      'height', 'intrinsicsize', 'loop', 'muted', 'playsinline', 'poster',
+      'preload', 'src', 'width'];
+    return allAttributes.filter(el => filter.includes(el));
+  })(),
+  // Counts the number of pictures using source media min-resolution
+  'num_picture_using_min_resolution': (() => {
+    var pictures = document.querySelectorAll('picture');
+    return Array.from(pictures).filter(picture => {
+      return picture.querySelector('source[media*="min-resolution"]');
+    }).length;
+  })(),
+  // Counts the number of pictures using source media orientation
+  'num_picture_using_orientation': (() => {
+    var pictures = document.querySelectorAll('picture');
+    return Array.from(pictures).filter(picture => {
+      return picture.querySelector('source[media*="orientation"]');
+    }).length;
+  })()
+});

--- a/custom_metrics/media.js
+++ b/custom_metrics/media.js
@@ -116,5 +116,21 @@ return JSON.stringify({
     return Array.from(pictures).filter(picture => {
       return picture.querySelector('source[media*="orientation"]');
     }).length;
+  })(),
+  // Counts the number of candidates for srcset of img that are not in picture
+  'num_img_not_in_picture_srcset_candidates': (() => {
+    var images = document.querySelectorAll('img[srcset]');
+    var nodes = Array.from(images).filter(image => {
+      return image.parentNode.tagName.toLowerCase() != 'picture';
+    });
+    var count = 0;
+    for (var node of nodes) {
+      var srcset = node.getAttribute('srcset');
+      if (!srcset) {
+        continue;
+      }
+      count += srcset.split(',').length;
+    }
+    return count;
   })()
 });


### PR DESCRIPTION
@rviscomi, here is another custom metric for the [2020 media chapter](https://github.com/HTTPArchive/almanac.httparchive.org/issues/900#issuecomment-660275165). 

[source/img with sizes attribute expensive sql with regexp](https://github.com/HTTPArchive/almanac.httparchive.org/blob/2189e7b3d80b94a09c9a1c59926ea63b3fe17c34/sql/2019/04_Media/04_06b.sql)

I combined both conditions in the same metric, just as in the original sql. They could also be split metrics. Also we could add an empty attribute condition - img[sizes]:not([sizes=""]). Please advise.

As for the tests:

[img sizes](https://www.webpagetest.org/custom_metrics.php?test=200720_ZN_74bb4163bcdd2aa25c0e58aeca955708&run=1&cached=0)

[source sizes](https://www.webpagetest.org/custom_metrics.php?test=200720_YZ_5f276fed83e36382e40654e2d714787c&run=1&cached=0)

[no img/source sizes](https://www.webpagetest.org/custom_metrics.php?test=200720_41_fbe1329b555858d0bacaec7650a59f03&run=1&cached=0)