### PR TITLE
New metrics and bug fixes

### DIFF
--- a/custom_metrics/almanac.js
+++ b/custom_metrics/almanac.js
@@ -607,22 +607,9 @@ return JSON.stringify({
   })(),
 
   'total_nodes_with_duplicate_ids': (() => {
-    const nodes_with_id = [...document.querySelectorAll('[id]')];
-    const id_count_map = new Map();
-    for (const node of nodes_with_id) {
-      const count = id_count_map.get(node.id) || 0;
-      id_count_map.set(node.id, count + 1);
-    }
-
-    let total_duplicates = 0;
-    for (const count of id_count_map.values()) {
-      if (count > 1) {
-        // Subtract one because the first div to have this ID is not a duplicate
-        total_duplicates += count - 1;
-      }
-    }
-
-    return total_duplicates;
+    const ids = [...document.querySelectorAll('[id]')].map(e => e.id);
+    const unique_ids = new Set(ids);
+    return ids.length - unique_ids.size;
   })(),
 
   /**

--- a/custom_metrics/almanac.js
+++ b/custom_metrics/almanac.js
@@ -383,5 +383,10 @@ return JSON.stringify({
     };
   }),
 
-
+  'scripts': (() => {
+    return {
+      total: document.scripts.length,
+      props: parseNodes(document.scripts),
+    };
+  }),
 });

--- a/custom_metrics/almanac.js
+++ b/custom_metrics/almanac.js
@@ -330,5 +330,58 @@ return JSON.stringify({
     }
   })(),
   //  check if there is any picture tag containing an img tag
-  'has_picture_img': document.querySelectorAll('picture img').length > 0
+  'has_picture_img': document.querySelectorAll('picture img').length > 0,
+
+  // Previously for 04_04.sql in 2019
+  'inline_svg_stats': (() => {
+    const svg_elements = [...document.querySelectorAll('svg')];
+
+    return {
+      total: svg_elements.length,
+      content_lengths: svg_elements.map(svg => svg.outerHTML.length),
+      props: parseNodes(svg_elements),
+    };
+  }),
+
+  // Various stats of img, source and picture elements
+  'images': (() => {
+    const pictures = document.querySelectorAll('picture');
+    const img = document.querySelectorAll('img');
+    const sources = document.querySelectorAll('source');
+
+    const pictures_with_img = document.querySelectorAll('picture img');
+    const images_with_srcset = document.querySelectorAll('img[srcset], source[srcset]');
+    const images_with_sizes = [...document.querySelectorAll('img[sizes], source[sizes]')];
+    const images_using_loading_prop = [...document.querySelectorAll('img[loading], source[loading]')];
+
+    return {
+      total_pictures: pictures.length,
+      total_img: img.length,
+      total_sources: sources.length,
+
+      total_with_srcset: images_with_srcset.length,
+      total_with_sizes: images_with_sizes.length,
+      total_pictures_with_img: pictures_with_img.length,
+
+      // Values specific properties. Cleaned and trimmed to make processing easier
+      sizes_values: images_with_sizes.map(img => img.sizes.replace(/[\r\n]+/g, ' ').replace(/\s+/g, ' ').trim()),
+      images_using_loading_prop: images_using_loading_prop.map(img => img.sizes.replace(/[\r\n]+/g, ' ').replace(/\s+/g, ' ').trim()),
+
+      // TODO: Should we really add all of this metadata? It may be helpful later on, but it will bloat the file
+      picture_props: parseNodes(pictures),
+      img_props: parseNodes(img),
+      source_props: parseNodes(sources),
+    };
+  }),
+
+  'videos': (() => {
+    const videos = document.querySelectorAll('video');
+
+    return {
+      total: videos.length,
+      props: parseNodes(videos),
+    };
+  }),
+
+
 });

--- a/custom_metrics/almanac.js
+++ b/custom_metrics/almanac.js
@@ -21,12 +21,11 @@ function getNodeAttributes(node) {
 }
 
 function parseNode(node) {
-  var attributes = Object.values(getNodeAttributes(node));
-  var el = {};
+  const attributes = Object.values(getNodeAttributes(node));
+  const el = {};
 
   el.tagName = node.tagName.toLowerCase(); // for reference
-  for (var n = 0, len2 = attributes.length; n < len2; n++) {
-    var attribute = attributes[n];
+  for (const attribute of attributes) {
     if (!attribute.name) {
       continue;
     }
@@ -39,11 +38,10 @@ function parseNode(node) {
 
 // Map nodes to their attributes,
 function parseNodes(nodes) {
-  var parsedNodes = [];
+  const parsedNodes = [];
   if (nodes) {
-    for (var i = 0, len = nodes.length; i < len; i++) {
-      var node = nodes[i];
-      var el = parseNode(node);
+    for (const node of nodes) {
+      const el = parseNode(node);
       parsedNodes.push(el);
     }
   }

--- a/custom_metrics/almanac.js
+++ b/custom_metrics/almanac.js
@@ -619,12 +619,6 @@ return JSON.stringify({
     };
   })(),
 
-  'total_nodes_with_duplicate_ids': (() => {
-    const ids = [...document.querySelectorAll('[id]')].map(e => e.id);
-    const unique_ids = new Set(ids);
-    return ids.length - unique_ids.size;
-  })(),
-
   /**
    * The 'h' is stripped to create a numeric array.
    * E.g. h1 > h2 > h3 > h3 => [1, 2, 3, 3, ]

--- a/custom_metrics/almanac.js
+++ b/custom_metrics/almanac.js
@@ -26,6 +26,10 @@ function parseNode(node) {
 
   el.tagName = node.tagName.toLowerCase(); // for reference
   for (var n = 0, len2 = attributes.length; n < len2; n++) {
+    if (!attribute.name) {
+      continue;
+    }
+
     var attribute = attributes[n];
     el[attribute.name.toLowerCase()] = attribute.value;
   }

--- a/custom_metrics/almanac.js
+++ b/custom_metrics/almanac.js
@@ -307,21 +307,6 @@ return JSON.stringify({
   })(),
   // Counts the links or buttons only containing an icon.
   'icon_only_clickables': (() => {
-    function containsAnSvg(element) {
-      var children = Array.from(element.childNodes);
-      return !!children.find((child) => {
-        if (child.tagName && child.tagName.toLowerCase() === 'svg') {
-          return true;
-        }
-
-        if (child.childNodes.length) {
-          return containsAnSvg(child);
-        }
-
-        return false;
-      });
-    }
-
     var clickables = document.querySelectorAll('a, button');
     return Array.from(clickables).reduce((n, clickable) => {
       var visible_text_length = clickable.textContent.trim().length;
@@ -333,7 +318,7 @@ return JSON.stringify({
         return n + 1;
       }
 
-      if (containsAnSvg(clickable)) {
+      if (clickable.querySelector('svg')) {
         // The icon in this case is an svg, so any other text is assumed to be a label
         if (visible_text_length >= 1) {
           return n;

--- a/custom_metrics/almanac.js
+++ b/custom_metrics/almanac.js
@@ -564,4 +564,20 @@ return JSON.stringify({
     // Returns a JSON array of meta nodes and their key/value attributes.
     return parseNode(document.body);
   }),
+
+  'html_node': (() => {
+    // Returns a JSON array of meta nodes and their key/value attributes.
+    return parseNode(document.documentElement);
+  }),
+
+  'document_title': (() => {
+    return {
+      value: document.title,
+      length: document.title.length
+    };
+  }),
+
+  'length_of_h1s': (() => {
+    return [...document.querySelectorAll('h1')].map(node => node.innerText.length);
+  }),
 });

--- a/custom_metrics/almanac.js
+++ b/custom_metrics/almanac.js
@@ -681,11 +681,13 @@ return JSON.stringify({
   })(),
 
   'body_node': (() => {
-    return parseNode(document.body).attributes;
+    // Only a single element, so we can keep the data values
+    return parseNode(document.body, {remove_data_prop_value: false}).attributes;
   })(),
 
   'html_node': (() => {
-    return parseNode(document.documentElement).attributes;
+    // Only a single element, so we can keep the data values
+    return parseNode(document.documentElement, {remove_data_prop_value: false}).attributes;
   })(),
 
   'document_title': (() => {

--- a/custom_metrics/almanac.js
+++ b/custom_metrics/almanac.js
@@ -26,11 +26,11 @@ function parseNode(node) {
 
   el.tagName = node.tagName.toLowerCase(); // for reference
   for (var n = 0, len2 = attributes.length; n < len2; n++) {
+    var attribute = attributes[n];
     if (!attribute.name) {
       continue;
     }
 
-    var attribute = attributes[n];
     el[attribute.name.toLowerCase()] = attribute.value;
   }
 

--- a/custom_metrics/almanac.js
+++ b/custom_metrics/almanac.js
@@ -411,15 +411,9 @@ return JSON.stringify({
       }),
       alt_tag_lengths: alt_tag_lengths,
 
-      // NOTE: props starting with __ are not actual properties. They were added by this script
       picture_props: parseNodes(pictures),
       img_props: imgs.map(img => {
         const props = parseNode(img);
-        props.__natural_width = img.naturalWidth;
-        props.__natural_height = img.naturalHeight;
-        props.__width = img.width;
-        props.__height = img.height;
-
         return props;
       }),
       source_props: parseNodes(sources),
@@ -445,15 +439,11 @@ return JSON.stringify({
   'nodes_using_role': (() => {
     const nodes_with_role = [...document.querySelectorAll('[role]')];
 
-    /**
-     * 1. Build an object with each key being a unique value of `role` and the value being how often this role occurred
-     * 2. Make a list of unique role values
-     */
-    const unique_values = new Set();
+    // Build an object with each key being a unique value of `role` and the
+    // value being how often this role occurred
     const role_values_and_count = {};
     for (const node of nodes_with_role) {
       const role = node.getAttribute('role').toLowerCase();
-      unique_values.add(role);
 
       if (!role_values_and_count[role]) {
         role_values_and_count[role] = 1;
@@ -466,7 +456,6 @@ return JSON.stringify({
     return {
       total: nodes_with_role.length,
       values_and_count: role_values_and_count,
-      unique_values: [...unique_values],
     };
   })(),
 
@@ -544,10 +533,9 @@ return JSON.stringify({
     return aria_nodes;
   })(),
 
+  // What attribute values are used and how often are they used
   // NOTE: This will not pick up all of the attributes on scripts
   'attributes_used_on_elements': (() => {
-    // Example usage: Process all elements on the page
-    const unique_values = new Set();
     const attributes_and_count = {};
     walkNodes(document.documentElement, (node) => {
       const attribute_names = node.getAttributeNames();
@@ -557,8 +545,6 @@ return JSON.stringify({
 
       // Count how often each of these attributes shows up
       for (const name of attribute_names) {
-        unique_values.add(name);
-
         if (!attributes_and_count[name]) {
           attributes_and_count[name] = 1;
           continue;
@@ -568,11 +554,7 @@ return JSON.stringify({
       }
     });
 
-    return {
-      // How often each of these values show up
-      values_and_count: attributes_and_count,
-      unique_values: [...unique_values],
-    };
+    return attributes_and_count;
   })(),
 
   'body_node': (() => {

--- a/custom_metrics/almanac.js
+++ b/custom_metrics/almanac.js
@@ -384,7 +384,6 @@ return JSON.stringify({
       images_using_loading_prop: images_using_loading_prop.map(img => img.sizes.replace(/[\r\n]+/g, ' ').replace(/\s+/g, ' ').trim()),
       alt_tag_lengths: alt_tag_lengths,
 
-      // TODO: Should we really add all of this metadata? It may be helpful later on, but it will bloat the file
       picture_props: parseNodes(pictures),
       img_props: parseNodes(img),
       source_props: parseNodes(sources),

--- a/custom_metrics/almanac.js
+++ b/custom_metrics/almanac.js
@@ -406,6 +406,19 @@ return JSON.stringify({
         /^id$/,
         /^name$/,
         /^placeholder$/,
+        /^accept$/,
+        /^autocomplete$/,
+        /^autofocus$/,
+        /^capture$/,
+        /^max$/,
+        /^maxlength$/,
+        /^min$/,
+        /^minlength$/,
+        /^required$/,
+        /^readonly$/,
+        /^pattern$/,
+        /^multiple$/,
+        /^step$/,
       ]
     });
 

--- a/custom_metrics/almanac.js
+++ b/custom_metrics/almanac.js
@@ -411,11 +411,12 @@ return JSON.stringify({
       }),
       alt_tag_lengths: alt_tag_lengths,
 
+      // NOTE: props starting with __ are not actual properties. They were added by this script
       picture_props: parseNodes(pictures),
       img_props: imgs.map(img => {
         const props = parseNode(img);
-        props.__naturalWidth = img.naturalWidth;
-        props.__naturalHeight = img.naturalHeight;
+        props.__natural_width = img.naturalWidth;
+        props.__natural_height = img.naturalHeight;
         props.__width = img.width;
         props.__height = img.height;
 

--- a/custom_metrics/almanac.js
+++ b/custom_metrics/almanac.js
@@ -374,7 +374,6 @@ return JSON.stringify({
     const sources = document.querySelectorAll('source');
     const pictures_with_img = document.querySelectorAll('picture img');
 
-    const pictures_with_img = document.querySelectorAll('picture img');
     const images_with_srcset = document.querySelectorAll('img[srcset], source[srcset]');
     const images_with_sizes = [...document.querySelectorAll('img[sizes], source[sizes]')];
     const images_using_loading_prop = [...document.querySelectorAll('img[loading], source[loading]')];

--- a/custom_metrics/almanac.js
+++ b/custom_metrics/almanac.js
@@ -557,6 +557,7 @@ return JSON.stringify({
 
   'videos': (() => {
     const videos = document.querySelectorAll('video');
+    const tracks = document.querySelectorAll('video track');
 
     const filter_options = {
       include_only_prop_list: [
@@ -571,11 +572,15 @@ return JSON.stringify({
       // Protect us from weird values
       max_prop_length: 255,
     };
-    return parseNodes(videos, filter_options);
+    const parsed_videos = parseNodes(videos, filter_options);
+
+    const parsed_tracks = parseNodes(tracks, {max_prop_length: 255});
+    parsed_videos.tracks = parsed_tracks;
+    return parsed_videos;
   })(),
 
   'scripts': (() => {
-    return parseNodes(document.scripts);
+    return parseNodes(document.scripts, {max_prop_length: 512});
   })(),
 
   'nodes_using_role': (() => {
@@ -649,36 +654,6 @@ return JSON.stringify({
       aria_shortcut_values: aria_shortcut_nodes.map(node => node.getAttribute('aria-keyshortcuts')),
       accesskey_values: accesskey_nodes.map(node => node.getAttribute('accesskey')),
     };
-  })(),
-
-  'nodes_using_aria': (() => {
-    // Example usage: Process all elements on the page
-    const aria_nodes = [];
-    walkNodes(document.documentElement, (node) => {
-      const attributes = node.getAttributeNames();
-      if (attributes.length <= 0) {
-        return;
-      }
-
-      let has_aria = false;
-      for (const attribute_name of attributes) {
-        if (attribute_name.toLowerCase().indexOf('aria-') === 0) {
-          // This node has aria, so we'll store all of its attributes and move on to the next node now
-          // This may return a lot of nodes, so we'll remove the value of some commonly used props
-          aria_nodes.push(
-              parseNode(node, {
-                other_prop_values_to_remove: [/^class$/, /^src$/],
-                max_prop_length: 255,
-              }).attributes
-          );
-          return;
-        }
-      }
-
-      // The node didn't have aria so we simply do nothing and move on to the next node
-    });
-
-    return aria_nodes;
   })(),
 
   // What attribute values are used and how often are they used

--- a/custom_metrics/almanac.js
+++ b/custom_metrics/almanac.js
@@ -355,8 +355,6 @@ return JSON.stringify({
       return null;
     }
   })(),
-  //  check if there is any picture tag containing an img tag
-  'has_picture_img': document.querySelectorAll('picture img').length > 0,
 
   // Previously for 04_04.sql in 2019
   'inline_svg_stats': (() => {
@@ -374,6 +372,7 @@ return JSON.stringify({
     const pictures = document.querySelectorAll('picture');
     const imgs = [...document.querySelectorAll('img')];
     const sources = document.querySelectorAll('source');
+    const pictures_with_img = document.querySelectorAll('picture img');
 
     const pictures_with_img = document.querySelectorAll('picture img');
     const images_with_srcset = document.querySelectorAll('img[srcset], source[srcset]');
@@ -576,12 +575,10 @@ return JSON.stringify({
   })(),
 
   'body_node': (() => {
-    // Returns a JSON array of meta nodes and their key/value attributes.
     return parseNode(document.body);
   })(),
 
   'html_node': (() => {
-    // Returns a JSON array of meta nodes and their key/value attributes.
     return parseNode(document.documentElement);
   })(),
 

--- a/custom_metrics/almanac.js
+++ b/custom_metrics/almanac.js
@@ -372,7 +372,7 @@ return JSON.stringify({
   // Various stats of img, source and picture elements
   'images': (() => {
     const pictures = document.querySelectorAll('picture');
-    const img = [...document.querySelectorAll('img')];
+    const imgs = [...document.querySelectorAll('img')];
     const sources = document.querySelectorAll('source');
 
     const pictures_with_img = document.querySelectorAll('picture img');
@@ -381,7 +381,7 @@ return JSON.stringify({
     const images_using_loading_prop = [...document.querySelectorAll('img[loading], source[loading]')];
 
     // NOTE: -1 is used to represent images with no alt tag at all. Empty alt tags have a value of 0
-    const alt_tag_lengths = img.map(img => {
+    const alt_tag_lengths = imgs.map(img => {
       if (!img.hasAttribute('alt')) {
         return -1;
       }
@@ -393,7 +393,7 @@ return JSON.stringify({
 
     return {
       total_pictures: pictures.length,
-      total_img: img.length,
+      total_img: imgs.length,
       total_sources: sources.length,
 
       total_with_srcset: images_with_srcset.length,
@@ -401,12 +401,18 @@ return JSON.stringify({
       total_pictures_with_img: pictures_with_img.length,
 
       // Values specific properties. Cleaned and trimmed to make processing easier
-      sizes_values: images_with_sizes.map(img => img.sizes.replace(/[\r\n]+/g, ' ').replace(/\s+/g, ' ').trim()),
-      images_using_loading_prop: images_using_loading_prop.map(img => img.sizes.replace(/[\r\n]+/g, ' ').replace(/\s+/g, ' ').trim()),
+      sizes_values: images_with_sizes.map(img => {
+        const value = img.getAttribute('sizes') || '';
+        return value.replace(/[\r\n]+/g, ' ').replace(/\s+/g, ' ').trim();
+      }),
+      loading_values: images_using_loading_prop.map(img => {
+        const value = img.getAttribute('loading') || '';
+        return value.replace(/[\r\n]+/g, ' ').replace(/\s+/g, ' ').trim();
+      }),
       alt_tag_lengths: alt_tag_lengths,
 
       picture_props: parseNodes(pictures),
-      img_props: parseNodes(img),
+      img_props: parseNodes(imgs),
       source_props: parseNodes(sources),
     };
   })(),
@@ -516,7 +522,7 @@ return JSON.stringify({
 
       let has_aria = false;
       for (const attribute_name of attributes) {
-        if (attribute_name.toLowerCase().indexOf('aria') === 0) {
+        if (attribute_name.toLowerCase().indexOf('aria-') === 0) {
           // This node has aria, so we'll store all of its attributes and move on to the next node now
           aria_nodes.push(parseNode(node));
           return;
@@ -535,21 +541,21 @@ return JSON.stringify({
     const unique_values = new Set();
     const attributes_and_count = {};
     walkNodes(document.documentElement, (node) => {
-      const attributes = node.getAttributeNames();
-      if (attributes.length <= 0) {
+      const attribute_names = node.getAttributeNames();
+      if (attribute_names.length <= 0) {
         return;
       }
 
-      unique_values.add(...attributes);
-
       // Count how often each of these attributes shows up
-      for (const attribute of attributes) {
-        if (!attributes_and_count[attribute]) {
-          attributes_and_count[attribute] = 1;
+      for (const name of attribute_names) {
+        unique_values.add(name);
+
+        if (!attributes_and_count[name]) {
+          attributes_and_count[name] = 1;
           continue;
         }
 
-        attributes_and_count[attribute]++;
+        attributes_and_count[name]++;
       }
     });
 

--- a/custom_metrics/almanac.js
+++ b/custom_metrics/almanac.js
@@ -277,7 +277,8 @@ return JSON.stringify({
 
     return parsedNodes;
   })(),
-  '12.11': (() => {
+  // Counts the links or buttons only containing an icon.
+  'icon_only_clickables': (() => {
     function containsAnSvg(element) {
       var children = Array.from(element.childNodes);
       return !!children.find((child) => {
@@ -293,7 +294,6 @@ return JSON.stringify({
       });
     }
 
-    // Counts the links or buttons only containing an icon.
     var clickables = document.querySelectorAll('a, button');
     return Array.from(clickables).reduce((n, clickable) => {
       var visible_text_length = clickable.textContent.trim().length;

--- a/custom_metrics/almanac.js
+++ b/custom_metrics/almanac.js
@@ -545,11 +545,11 @@ return JSON.stringify({
       // Values specific properties. Cleaned and trimmed to make processing easier
       sizes_values: images_with_sizes.map(img => {
         const value = img.getAttribute('sizes') || '';
-        return value.toLoacleLowerCase().replace(/\s+/g, ' ').trim();
+        return value.toLocaleLowerCase().replace(/\s+/g, ' ').trim();
       }),
       loading_values: images_using_loading.map(img => {
         const value = img.getAttribute('loading') || '';
-        return value.toLoacleLowerCase().replace(/\s+/gm, ' ').trim();
+        return value.toLocaleLowerCase().replace(/\s+/gm, ' ').trim();
       }),
       alt_lengths: alt_lengths,
     };
@@ -590,7 +590,7 @@ return JSON.stringify({
     // value being how often this role occurred
     const role_usage_and_count = {};
     for (const node of nodes_with_role) {
-      const role = node.getAttribute('role').toLoacleLowerCase();
+      const role = node.getAttribute('role').toLocaleLowerCase();
 
       if (!role_usage_and_count[role]) {
         role_usage_and_count[role] = 1;
@@ -638,7 +638,7 @@ return JSON.stringify({
       total_with_accesskey: accesskey_nodes.length,
 
       // Purposely left these as potentially duplicated fields so we can analyze if the same value is used more than once
-      aria_shortcut_values: aria_shortcut_nodes.map(node => node.getAttribute('aria-keyshortcuts').toLoacleLowerCase()),
+      aria_shortcut_values: aria_shortcut_nodes.map(node => node.getAttribute('aria-keyshortcuts').toLocaleLowerCase()),
       accesskey_values: accesskey_nodes.map(node => node.getAttribute('accesskey')),
     };
   })(),

--- a/custom_metrics/almanac.js
+++ b/custom_metrics/almanac.js
@@ -346,7 +346,7 @@ return JSON.stringify({
       content_lengths: svg_elements.map(svg => svg.outerHTML.length),
       props: parseNodes(svg_elements),
     };
-  }),
+  })(),
 
   // Various stats of img, source and picture elements
   'images': (() => {
@@ -388,7 +388,7 @@ return JSON.stringify({
       img_props: parseNodes(img),
       source_props: parseNodes(sources),
     };
-  }),
+  })(),
 
   'videos': (() => {
     const videos = document.querySelectorAll('video');
@@ -397,14 +397,14 @@ return JSON.stringify({
       total: videos.length,
       props: parseNodes(videos),
     };
-  }),
+  })(),
 
   'scripts': (() => {
     return {
       total: document.scripts.length,
       props: parseNodes(document.scripts),
     };
-  }),
+  })(),
 
   'nodes_using_role': (() => {
     const nodes_with_role = [...document.querySelectorAll('[role]')];
@@ -432,7 +432,7 @@ return JSON.stringify({
       values_and_count: role_values_and_count,
       unique_values: [...unique_values],
     };
-  }),
+  })(),
 
   'total_nodes_with_duplicate_ids': (() => {
     const nodes_with_id = [...document.querySelectorAll('[id]')];
@@ -451,7 +451,7 @@ return JSON.stringify({
     }
 
     return total_duplicates;
-  }),
+  })(),
 
   /**
    * The 'h' is stripped to create a numeric array.
@@ -468,7 +468,7 @@ return JSON.stringify({
     }
 
     return levels;
-  }),
+  })(),
 
   'shortcuts_stats': (() => {
     const aria_shortcut_nodes = [...document.querySelectorAll('[aria-keyshortcuts]')];
@@ -482,7 +482,7 @@ return JSON.stringify({
       aria_shortcut_values: aria_shortcut_nodes.map(node => node.getAttribute('aria-keyshortcuts')),
       accesskey_values: accesskey_nodes.map(node => node.getAttribute('accesskey')),
     };
-  }),
+  })(),
 
   'nodes_using_aria': (() => {
     const nodes_with_role = [...document.querySelectorAll('[aria-*]')];
@@ -510,7 +510,7 @@ return JSON.stringify({
       values_and_count: role_values_and_count,
       unique_values: [...unique_values],
     };
-  }),
+  })(),
 
   // NOTE: This will not pick up all of the attributes on scripts
   'attributes_used_on_elements': (() => {
@@ -557,26 +557,26 @@ return JSON.stringify({
       values_and_count: attributes_and_count,
       unique_values: [...unique_values],
     };
-  }),
+  })(),
 
   'body_node': (() => {
     // Returns a JSON array of meta nodes and their key/value attributes.
     return parseNode(document.body);
-  }),
+  })(),
 
   'html_node': (() => {
     // Returns a JSON array of meta nodes and their key/value attributes.
     return parseNode(document.documentElement);
-  }),
+  })(),
 
   'document_title': (() => {
     return {
       value: document.title,
       length: document.title.length
     };
-  }),
+  })(),
 
   'length_of_h1s': (() => {
     return [...document.querySelectorAll('h1')].map(node => node.innerText.length);
-  }),
+  })(),
 });

--- a/custom_metrics/almanac.js
+++ b/custom_metrics/almanac.js
@@ -278,19 +278,42 @@ return JSON.stringify({
     return parsedNodes;
   })(),
   '12.11': (() => {
+    function containsAnSvg(element) {
+      var children = Array.from(element.childNodes);
+      return !!children.find((child) => {
+        if (child.tagName && child.tagName.toLowerCase() === 'svg') {
+          return true;
+        }
+
+        if (child.childNodes.length) {
+          return containsAnSvg(child);
+        }
+
+        return false;
+      });
+    }
+
     // Counts the links or buttons only containing an icon.
     var clickables = document.querySelectorAll('a, button');
     return Array.from(clickables).reduce((n, clickable) => {
-      // Clickables containing SVG are assumed to be icons.
-      if (clickable.firstElementChild && clickable.firstElementChild.tagName == 'SVG') {
-        return n + 1;
-      }
+      var visible_text_length = clickable.textContent.trim().length;
+
       // Clickables containing 1-char text are assumed to be icons.
       // Note that this fails spectacularly for complex unicode points.
       // See https://blog.jonnew.com/posts/poo-dot-length-equals-two.
-      if (clickable.textContent.trim().length == 1) {
+      if (visible_text_length == 1) {
         return n + 1;
       }
+
+      if (containsAnSvg(clickable)) {
+        // The icon in this case is an svg, so any other text is assumed to be a label
+        if (visible_text_length >= 1) {
+          return n;
+        }
+
+        return n + 1;
+      }
+
       return n;
     }, 0);
   })(),

--- a/custom_metrics/almanac.js
+++ b/custom_metrics/almanac.js
@@ -497,10 +497,10 @@ return JSON.stringify({
 
     const images_with_srcset = document.querySelectorAll('img[srcset], source[srcset]');
     const images_with_sizes = [...document.querySelectorAll('img[sizes], source[sizes]')];
-    const images_using_loading_prop = [...document.querySelectorAll('img[loading], source[loading]')];
+    const images_using_loading = [...document.querySelectorAll('img[loading], source[loading]')];
 
     // NOTE: -1 is used to represent images with no alt tag at all. Empty alt tags have a value of 0
-    const alt_tag_lengths = imgs.map(img => {
+    const alt_lengths = imgs.map(img => {
       if (!img.hasAttribute('alt')) {
         return -1;
       }
@@ -545,13 +545,13 @@ return JSON.stringify({
       // Values specific properties. Cleaned and trimmed to make processing easier
       sizes_values: images_with_sizes.map(img => {
         const value = img.getAttribute('sizes') || '';
-        return value.replace(/[\r\n]+/g, ' ').replace(/\s+/g, ' ').trim();
+        return value.toLoacleLowerCase().replace(/\s+/g, ' ').trim();
       }),
-      loading_values: images_using_loading_prop.map(img => {
+      loading_values: images_using_loading.map(img => {
         const value = img.getAttribute('loading') || '';
-        return value.replace(/[\r\n]+/g, ' ').replace(/\s+/g, ' ').trim();
+        return value.toLoacleLowerCase().replace(/\s+/gm, ' ').trim();
       }),
-      alt_tag_lengths: alt_tag_lengths,
+      alt_lengths: alt_lengths,
     };
   })(),
 
@@ -590,7 +590,7 @@ return JSON.stringify({
     // value being how often this role occurred
     const role_usage_and_count = {};
     for (const node of nodes_with_role) {
-      const role = node.getAttribute('role').toLowerCase();
+      const role = node.getAttribute('role').toLoacleLowerCase();
 
       if (!role_usage_and_count[role]) {
         role_usage_and_count[role] = 1;
@@ -638,7 +638,7 @@ return JSON.stringify({
       total_with_accesskey: accesskey_nodes.length,
 
       // Purposely left these as potentially duplicated fields so we can analyze if the same value is used more than once
-      aria_shortcut_values: aria_shortcut_nodes.map(node => node.getAttribute('aria-keyshortcuts')),
+      aria_shortcut_values: aria_shortcut_nodes.map(node => node.getAttribute('aria-keyshortcuts').toLoacleLowerCase()),
       accesskey_values: accesskey_nodes.map(node => node.getAttribute('accesskey')),
     };
   })(),

--- a/custom_metrics/almanac.js
+++ b/custom_metrics/almanac.js
@@ -412,7 +412,15 @@ return JSON.stringify({
       alt_tag_lengths: alt_tag_lengths,
 
       picture_props: parseNodes(pictures),
-      img_props: parseNodes(imgs),
+      img_props: imgs.map(img => {
+        const props = parseNode(img);
+        props.__naturalWidth = img.naturalWidth;
+        props.__naturalHeight = img.naturalHeight;
+        props.__width = img.width;
+        props.__height = img.height;
+
+        return props;
+      }),
       source_props: parseNodes(sources),
     };
   })(),


### PR DESCRIPTION
I've looked through all of the metrics from 2019 and created new functions to minimize the use of regex this year.

Here are the summaries:

### Metric to Function mapping

| Metric | Function to use |
| ------ | --------------- |
| 04_04.sql | inline_svg_stats |
| 04_06.sql | images.(total_*) |
| 04_06b.sql | images.sizes_values |
| 04_08.sql | image_stats.total_pictures_with_img |
| 04_09a.sql | meta-nodes should already take care what is portable here |
| 04_09b.sql | meta-nodes should already take care what is portable here |
| 04_09c.sql | meta-nodes should already take care what is portable here |
| 04_09d.sql | meta-nodes and images.sizes_values |
| 04_19.sql | videos |
| 04_26.sql | images.images_using_loading_prop |
| 08_32.sql | Using headers |
| 08_33.sql | Using headers |
| 08_35-37.sql | Using headers |
| 08_39.sql | scripts and link-nodes |
| 08_42.sql | Using headers |
| 09_02.sql | nodes_using_role |
| 09_04.sql | nodes_using_role |
| 09_05.sql | nodes_using_role |
| 09_05b.sql | nodes_using_role |
| 09_06.sql | total_nodes_with_duplicate_ids |
| 09_11.sql | heading-order from Axe https://dequeuniversity.com/rules/axe/3.0/heading-order |
| 09_13.sql | headings_order |
| 09_14.sql | shortcuts_stats |
| 09_15.sql | shortcuts_stats |
| 09_16.sql | Can use input-elements |
| 09_16b.sql | Can use input-elements |
| 09_17.sql | nodes_using_role |
| 09_19a.sql | attributes_used_on_elements |
| 09_19b.sql | attributes_used_on_elements |
| 09_19c.sql | attributes_used_on_elements |
| 09_22.sql | body_node |
| 09_24.sql | attributes_used_on_elements |
| 09_32b.sql | images.alt_tag_lengths |
| 10_02.sql | html_node |
| 10_04a.sql | link-nodes |
| 10_04b.sql | link-nodes |
| 10_07b.sql | document_title |
| 10_16.sql | length_of_h1s |
| 14_02.sql | meta-nodes |
| 14_03.sql | meta-nodes |

### Metrics unable to create a function for

| Metric | Reason |
| ------ | ------ |
| 01_18.sql | Its scanning javascript |
| 01_24.sql | Its scanning javascript |
| 01_25.sql | Its scanning javascript |
| 02_11.sql | Cant grab css comments from the DOM |
| 02_45.sql | Possible, but would bloat the custom metrics. The result of this would be an array of numbers where each number represents the number of classes that were used on an element. So this list would be gigantic... But because we want to use percentiles there's no other way to store this information. Thoughts? |
| 11_06.sql | Its scanning javascript |

### Metrics which were moved

1. `has_picture_img` is now `images.total_pictures_with_img`. Instead of reporting a boolean it reports how many occurrences there were