### PR TITLE
[sass] Add constants usage count (e & pi)

### DIFF
--- a/custom_metrics/sass.js
+++ b/custom_metrics/sass.js
@@ -189,6 +189,11 @@ function analyzeSCSS(scss, ret) {
 		"class": scss.match(/&\.\w+/g)?.length,
 		"attr": scss.match(/&\[\w+/g)?.length,
 	};
+
+	ret.constants = {
+		e: scss.match(/\bmath\.$e\b/g)?.length,
+		pi: scss.match(/\bmath\.$pi\b/g)?.length
+	};
 }
 
 let results = (async () => {


### PR DESCRIPTION
This counts how many times (if any) the constants for e and π are used.

Progress on https://github.com/HTTPArchive/almanac.httparchive.org/issues/898