### PR TITLE
Added i to make selectors case insensitive

### DIFF
--- a/custom_metrics/almanac.js
+++ b/custom_metrics/almanac.js
@@ -481,9 +481,9 @@ return JSON.stringify({
     // Gets metadata about the AMP plugin, if present.
     // Used by 14.2, 14.3, 14.4.
     try {
-      var metadata = document.querySelector('meta[name=generator][content^="AMP Plugin"]');
+      var metadata = document.querySelector("meta[name='generator'i][content^='AMP Plugin'i]");
       if (metadata) {
-        return metadata.getAttribute('content');
+        return metadata.getAttribute('content'); // this can now vary by case
       }
     } catch (e) {
       return null;

--- a/custom_metrics/almanac.js
+++ b/custom_metrics/almanac.js
@@ -483,7 +483,7 @@ return JSON.stringify({
     try {
       var metadata = document.querySelector("meta[name='generator'i][content^='AMP Plugin'i]");
       if (metadata) {
-        return metadata.getAttribute('content'); // this can now vary by case
+        return metadata.getAttribute('content');
       }
     } catch (e) {
       return null;

--- a/custom_metrics/markup.js
+++ b/custom_metrics/markup.js
@@ -53,8 +53,8 @@ var _custom_metrics = null;
 try { // whole process is placed in a try/catch so we can log uncaught errors
 
   _custom_metrics = {
-    'favicon': !!document.querySelector('link[rel*="icon"]'),
-    'rel_alternate_mobile': !!document.querySelector('link[rel="alternate"][media][href]'),
+    'favicon': !!document.querySelector('link[rel*="icon"i]'),
+    'rel_alternate_mobile': !!document.querySelector('link[rel="alternate"i][media][href]'),
     'compatMode': document.compatMode,
 
     // noscript tag use
@@ -473,9 +473,9 @@ try { // whole process is placed in a try/catch so we can log uncaught errors
 
         result.amp_page = result.html_amp_attribute_present || result.html_amp_emoji_attribute_present;
 
-        result.rel_amphtml = document.querySelector("link[rel='amphtml']")?.getAttribute('href') ?? null;
+        result.rel_amphtml = document.querySelector("link[rel='amphtml'i]")?.getAttribute('href') ?? null;
 
-        var metadata = document.querySelector('meta[name=generator][content^="AMP Plugin"]');
+        var metadata = document.querySelector("meta[name='generator'i][content^='AMP Plugin'i]");
         if (metadata) {
           result.amp_plugin =  metadata.getAttribute('content') ?? null;
         }
@@ -536,10 +536,10 @@ try { // whole process is placed in a try/catch so we can log uncaught errors
         let result = {};
 
         result.svg_element_total = document.querySelectorAll('svg').length;
-        result.svg_img_total = document.querySelectorAll('img[src*=".svg"]').length;
-        result.svg_object_total = document.querySelectorAll('object[data*=".svg"]').length;
-        result.svg_embed_total = document.querySelectorAll('embed[src*=".svg"]').length;
-        result.svg_iframe_total = document.querySelectorAll('iframe[src*=".svg"]').length;
+        result.svg_img_total = document.querySelectorAll('img[src*=".svg"i]').length;
+        result.svg_object_total = document.querySelectorAll('object[data*=".svg"i]').length;
+        result.svg_embed_total = document.querySelectorAll('embed[src*=".svg"i]').length;
+        result.svg_iframe_total = document.querySelectorAll('iframe[src*=".svg"i]').length;
 
         result.svg_total = result.svg_element_total+result.svg_img_total+result.svg_object_total+result.svg_embed_total+result.svg_iframe_total;
 
@@ -560,7 +560,7 @@ try { // whole process is placed in a try/catch so we can log uncaught errors
         result.app_id_present = !!document.getElementById("app");
 
         // `<meta name="theme-color">` 
-        result.meta_theme_color = document.querySelector('meta[name="theme-color"]')?.getAttribute('content') ?? null;
+        result.meta_theme_color = document.querySelector('meta[name="theme-color"i]')?.getAttribute('content') ?? null;
 
         return result;
       }

--- a/custom_metrics/wpt_bodies.js
+++ b/custom_metrics/wpt_bodies.js
@@ -300,7 +300,7 @@ try { // whole process is placed in a try/catch so we can log uncaught errors
                       target.same_page.jumpto.other++;
                     }
 
-                  } else if (d.querySelector("*[name='"+id+"']")) { // then try matching name
+                  } else if (d.querySelector("*[name='"+id+"'i]")) { // then try matching name
                     // working named anchor link
                     target.same_page.jumpto.total++;
                     target.same_page.jumpto.using_name++;
@@ -552,7 +552,7 @@ try { // whole process is placed in a try/catch so we can log uncaught errors
 
         function getMetaDescriptions(d) {
           let target = {all: {text: "", words: 0, characters: 0}};       
-          target.total = [...d.querySelectorAll('head meta[name="description"]')].map(e => {
+          target.total = [...d.querySelectorAll('head meta[name="description"i]')].map(e => {
             let text = e.getAttribute("content") ?? "";
             let characters = text.length;
             let words = text.match(/\S+/g)?.length;
@@ -610,7 +610,7 @@ try { // whole process is placed in a try/catch so we can log uncaught errors
         function getHreflangValues(d) {
           let target = {values: []};
 
-          [...d.querySelectorAll('link[rel="alternate"][hreflang]')].forEach(e => {
+          [...d.querySelectorAll('link[rel="alternate"i][hreflang]')].forEach(e => {
             target.values.push(e.getAttribute("hreflang"));
           });
 
@@ -920,7 +920,7 @@ try { // whole process is placed in a try/catch so we can log uncaught errors
           let jsonldIds = {};
 
           // json-ld
-          let jsonld_scripts = [...d.querySelectorAll('script[type="application/ld+json"]')];
+          let jsonld_scripts = [...d.querySelectorAll('script[type="application/ld+json"i]')];
 
           target.jsonld_scripts = {
             count: jsonld_scripts.length,
@@ -1108,7 +1108,7 @@ try { // whole process is placed in a try/catch so we can log uncaught errors
         // raw canonicals
         let rawHtmlDocument = getRawHtmlDocument();
         if (rawHtmlDocument) {
-          result.raw.html_link_canoncials = [...rawHtmlDocument.querySelectorAll('link[rel="canonical"]')].map(n => {
+          result.raw.html_link_canoncials = [...rawHtmlDocument.querySelectorAll('link[rel="canonical"i]')].map(n => {
             let c = n.href ?? "";
             processCanonical(c);
             return c;
@@ -1116,7 +1116,7 @@ try { // whole process is placed in a try/catch so we can log uncaught errors
         }
 
         // rendered
-        let htmlCanonicalLinks = [...document.querySelectorAll('link[rel="canonical"]')].map(n => {
+        let htmlCanonicalLinks = [...document.querySelectorAll('link[rel="canonical"i]')].map(n => {
           let c = n.href ?? "";
           processCanonical(c);
           return c;
@@ -1250,13 +1250,13 @@ try { // whole process is placed in a try/catch so we can log uncaught errors
 
         function calculateAllRobots(d) {
           let r = {
-            otherbot: calculateRobots(d, 'meta[name="robots"]', 'otherbot'),
-            googlebot: calculateRobots(d, 'meta[name="robots"], meta[name="googlebot"]', 'googlebot'),
-            googlebot_news: calculateRobots(d, 'meta[name="robots"], meta[name="googlebot-news"]', 'googlebot-news'),
+            otherbot: calculateRobots(d, 'meta[name="robots"i]', 'otherbot'),
+            googlebot: calculateRobots(d, 'meta[name="robots"i], meta[name="googlebot"i]', 'googlebot'),
+            googlebot_news: calculateRobots(d, 'meta[name="robots"i], meta[name="googlebot-news"i]', 'googlebot-news'),
             google: {}
           };
           // Find all Google values
-          [...d.querySelectorAll("meta[name='google']")].forEach((n) => {
+          [...d.querySelectorAll("meta[name='google'i]")].forEach((n) => {
               let v = n.getAttribute("content");
 
               if (v) {


### PR DESCRIPTION
#188 

I checked all the custom metrics for potential issues with them using css selectors that needed to be set to case insensitive. This pull adds i to them to make them case insensitive.

I also found potential issue with third-parties.js but it's code is auto generated. It uses selectors to detect the generator meta tag, but I think will only capture that if generator is lowercase.

I did some basic testing to check a a few cases from each file to see that it was now being case insensitive, and that the scripts ran without errors. 

