### PR TITLE
added fetchWithTimeout and error checking for when it does time out

### DIFF
--- a/custom_metrics/ecommerce.js
+++ b/custom_metrics/ecommerce.js
@@ -8,16 +8,21 @@
 // 3. Test your change by following the instructions at https://github.com/HTTPArchive/almanac.httparchive.org/issues/33#issuecomment-502288773.
 // 4. Submit a PR to update this file.
 
+function fetchWithTimeout(url) {
+  var controller = new AbortController();
+  setTimeout(() => {controller.abort()}, 5000);
+  return fetch(url, {signal: controller.signal});
+}
 
 return Promise.all([
-  fetch('/.well-known/assetlinks.json').then(function(r) {
+  fetchWithTimeout('/.well-known/assetlinks.json').then(function(r) {
     if(!r.redirected && r.status === 200) {
      return 1;
     } else {
      return 0;
     }
   }),
-  fetch('/.well-known/apple-app-site-association').then(function(r) {
+  fetchWithTimeout('/.well-known/apple-app-site-association').then(function(r) {
     if(!r.redirected && r.status === 200) {
       return 1;
     } else {
@@ -26,4 +31,6 @@ return Promise.all([
   })
 ]).then(([AndroidAppLinks, iOSUniveralLinks]) => {
   return JSON.stringify({AndroidAppLinks, iOSUniveralLinks});
+}).catch(error => {
+  return JSON.stringify({message: error.message, error: error});
 });

--- a/custom_metrics/robots_txt.js
+++ b/custom_metrics/robots_txt.js
@@ -1,5 +1,12 @@
 //[robots_txt]
-return fetch('/robots.txt')
+
+function fetchWithTimeout(url) {
+  var controller = new AbortController();
+  setTimeout(() => {controller.abort()}, 5000);
+  return fetch(url, {signal: controller.signal});
+}
+
+return fetchWithTimeout('/robots.txt')
   .then(r => {
     let result = {};
     result.redirected = !!r.redirected;

--- a/custom_metrics/sass.js
+++ b/custom_metrics/sass.js
@@ -1,4 +1,11 @@
 //[sass]
+
+function fetchWithTimeout(url) {
+	var controller = new AbortController();
+	setTimeout(() => {controller.abort()}, 5000);
+	return fetch(url, {signal: controller.signal});
+}
+
 const SassFunctions = [
 	// Color
 	"color.adjust", "adjust-color",
@@ -238,7 +245,7 @@ if (sourcemapURLs.length === 0) {
 // Assumption: Either all sources are SCSS or none.
 let scss = await Promise.all(sourcemapURLs.map(async url => {
 	try {
-		var response = await fetch(url);
+		var response = await fetchWithTimeout(url);
 		var json = await response.json();
 	}
 	catch (e) {
@@ -271,9 +278,16 @@ let scss = await Promise.all(sourcemapURLs.map(async url => {
 		}
 
 		let code = await Promise.all(sources.map(async s => {
-			let response = await fetch(s);
-			let text = response.ok? await response.text() : "";
-			return text;
+			try {
+				let response = await fetchWithTimeout(s);
+				let text = response.ok? await response.text() : "";
+
+				return text;
+			}
+			catch (e) {
+				return "";
+			}
+			
 		}));
 
 		return code.join("\n");


### PR DESCRIPTION
fixes #192 

I tested each with a success scenario with the 5000ms timeout and a fail scenario caused by setting the timeout to 10ms.

ecommerce and robots_txt return this on timeout:

`{"message":"The user aborted a request.","error":{}}`

sass was a bit more complex. I don't know how to do a real world test for this. 

It uses async calls. One fetch was already in a try/catch which I tested by faking the scenario that causes the fetches. It would behave in the same way any error would have been handed before, eats it.

I added a try/catch to the  second fetch so that it behaves in the same way as the response not being ok.

