### PR TITLE
include href attribute for SRI custom metric

### DIFF
--- a/custom_metrics/security.js
+++ b/custom_metrics/security.js
@@ -13,7 +13,7 @@ return JSON.stringify({
   "sri-integrity": Array.from(document.querySelectorAll('[integrity]')).map((element) => {
     return {
       "integrity": element.getAttribute('integrity'),
-      "src": element.getAttribute('src'),
+      "src": element.getAttribute('src') || element.getAttribute('href'),
       "tagname": element.tagName.toLowerCase()
     }
   })


### PR DESCRIPTION
`<link>` elements can have SRI, but use a `href` attribute to point to the resource