### PR TITLE
PWA custom metric

### DIFF
--- a/custom_metrics/event-names.js
+++ b/custom_metrics/event-names.js
@@ -1,0 +1,9 @@
+const response_bodies = $WPT_BODIES;
+const eventNamePattern = /addEventListener\([\'"`](\w+)/g;
+
+return Object.fromEntries(response_bodies.filter(har => {
+  return eventNamePattern.test(har.response_body);
+}).map(har => {
+  const eventNames = Array.from(har.response_body.matchAll(eventNamePattern)).map(match => match[1]);
+  return [har.url, eventNames];
+}));

--- a/custom_metrics/initiators.js
+++ b/custom_metrics/initiators.js
@@ -1,0 +1,11 @@
+const requests = $WPT_REQUESTS;
+return requests.reduce((map, request) => {
+  const url = request.url;
+  let initiator = request.initiator.url;
+  if (!initiator) {
+    initiator = request.initiator?.stack?.callFrames?.[0]?.url
+  }
+  map[initiator] = map[initiator] || [];
+  map[initiator].push(url);
+  return map;
+}, {});

--- a/custom_metrics/pwa.js
+++ b/custom_metrics/pwa.js
@@ -69,9 +69,7 @@ const manifests = getEntriesForURLs(manifestURLs).map(([url, body]) => {
 const serviceWorkerInitiatedURLs = new Set(Array.from(serviceWorkerURLs).flatMap(getURLsInitiatedBy));
 const serviceWorkerInitiated = getEntriesForURLs(serviceWorkerInitiatedURLs);
 
-const workboxPattern = /workbox\.([a-zA-Z]+\.?[a-zA-Z]*)/g;
-const workboxPackagePattern = /([a-zA-Z]+)\.?[a-zA-Z]*/;
-const workboxMethodPattern = /([a-zA-Z]+\.?[a-zA-Z]*)/;
+const workboxPattern = /(?:workbox:[a-z\-]+:\d|workbox\.[a-zA-Z]+\.?[a-zA-Z]*)/g;
 // We should use serviceWorkerInitiatedURLs here, but SW detection has some false negatives.
 const workboxInfo = response_bodies.filter(har => {
   return workboxPattern.test(har.response_body);

--- a/custom_metrics/pwa.js
+++ b/custom_metrics/pwa.js
@@ -84,6 +84,5 @@ return {
   serviceWorkers: Object.fromEntries(serviceWorkers),
   manifests: Object.fromEntries(manifests),
   serviceWorkerInitiated: Object.fromEntries(serviceWorkerInitiated),
-  workboxInfo: Object.fromEntries(workboxInfo),
-  initiatorMap
+  workboxInfo: Object.fromEntries(workboxInfo)
 };

--- a/custom_metrics/pwa.js
+++ b/custom_metrics/pwa.js
@@ -69,7 +69,7 @@ const manifests = getEntriesForURLs(manifestURLs).map(([url, body]) => {
 const serviceWorkerInitiatedURLs = new Set(Array.from(serviceWorkerURLs).flatMap(getURLsInitiatedBy));
 const serviceWorkerInitiated = getEntriesForURLs(serviceWorkerInitiatedURLs);
 
-const workboxPattern = /(?:workbox:[a-z\-]+:\d|workbox\.[a-zA-Z]+\.?[a-zA-Z]*)/g;
+const workboxPattern = /(?:workbox:[a-z\-]+:[\d.]+|workbox\.[a-zA-Z]+\.?[a-zA-Z]*)/g;
 // We should use serviceWorkerInitiatedURLs here, but SW detection has some false negatives.
 const workboxInfo = response_bodies.filter(har => {
   return workboxPattern.test(har.response_body);

--- a/custom_metrics/pwa.js
+++ b/custom_metrics/pwa.js
@@ -72,17 +72,16 @@ const serviceWorkerInitiated = getEntriesForURLs(serviceWorkerInitiatedURLs);
 const workboxPattern = /workbox\.([a-zA-Z]+\.?[a-zA-Z]*)/g;
 const workboxPackagePattern = /([a-zA-Z]+)\.?[a-zA-Z]*/;
 const workboxMethodPattern = /([a-zA-Z]+\.?[a-zA-Z]*)/;
-const workboxInfo = serviceWorkerInitiated.filter(([url, body]) => {
-  return workboxPattern.test(body);
-}).map(([url, body]) => {
-  return [url, Array.from(body.matchAll(workboxPattern)).map(([match]) => {
-    return match;
-  })];
+// We should use serviceWorkerInitiatedURLs here, but SW detection has some false negatives.
+const workboxInfo = response_bodies.filter(har => {
+  return workboxPattern.test(har.response_body);
+}).map(har => {
+  return [har.url, Array.from(har.response_body.matchAll(workboxPattern)).map(m => m[0])];
 });
 
 return {
   serviceWorkers: Object.fromEntries(serviceWorkers),
   manifests: Object.fromEntries(manifests),
-  serviceWorkerInitiated: Object.fromEntries(serviceWorkerInitiated),
+  serviceWorkerInitiated: Object.keys(Object.fromEntries(serviceWorkerInitiated)),
   workboxInfo: Object.fromEntries(workboxInfo)
 };

--- a/custom_metrics/pwa.js
+++ b/custom_metrics/pwa.js
@@ -1,0 +1,89 @@
+//[pwa]
+const response_bodies = $WPT_BODIES;
+const requests = $WPT_REQUESTS;
+const serviceWorkerRegistrationPattern = /navigator\.serviceWorker\.register\(['"]([^"']+)/m;
+
+const serviceWorkerURLs = response_bodies.filter(har => {
+  return serviceWorkerRegistrationPattern.test(har.response_body);
+}).map(har => {
+  const base = new URL(har.url).origin;
+  const serviceWorkerPath = har.response_body.match(serviceWorkerRegistrationPattern)[1];
+  return new URL(serviceWorkerPath, base).href;
+}).reduce((set, url) => {
+  set.add(url);
+  return set;
+}, new Set());
+
+
+const manifestURLs = new Set(Array.from(document.querySelectorAll('link[rel=manifest]')).map(link => {
+  const base = new URL(location.href).origin;
+  const href = link.getAttribute('href');
+  return new URL(href, base).href;
+}));
+
+
+const initiatorMap = requests.reduce((map, request) => {
+  const url = request.url;
+  let initiator = request.initiator.url;
+  if (!initiator) {
+    initiator = request.initiator?.stack?.callFrames?.[0]?.url
+  }
+  map[initiator] = map[initiator] || [];
+  map[initiator].push(url);
+  return map;
+}, {});
+
+function getURLsInitiatedBy(initialURL) {
+  let initiatorChain = [initialURL];
+  for (let i = 0; i < initiatorChain.length; i++) {
+    const url = initiatorChain[i];
+    if (url in initiatorMap) {
+      initiatorChain = initiatorChain.concat(initiatorMap[url].filter(url => {
+        return !initiatorChain.includes(url);
+      }));
+    }
+  }
+  return initiatorChain;
+}
+
+function getEntriesForURLs(urlSet) {
+  return response_bodies.filter(har => {
+    return urlSet.has(har.url);
+  }).map(har => {
+    return [har.url, har.response_body];
+  });
+}
+
+const serviceWorkers = getEntriesForURLs(serviceWorkerURLs);
+const manifests = getEntriesForURLs(manifestURLs).map(([url, body]) => {
+  let manifest;
+  try {
+    manifest = JSON.parse(body);
+  } catch (e) {
+    manifest = body;
+  }
+  return [url, manifest];
+});
+
+
+const serviceWorkerInitiatedURLs = new Set(Array.from(serviceWorkerURLs).flatMap(getURLsInitiatedBy));
+const serviceWorkerInitiated = getEntriesForURLs(serviceWorkerInitiatedURLs);
+
+const workboxPattern = /workbox\.([a-zA-Z]+\.?[a-zA-Z]*)/g;
+const workboxPackagePattern = /([a-zA-Z]+)\.?[a-zA-Z]*/;
+const workboxMethodPattern = /([a-zA-Z]+\.?[a-zA-Z]*)/;
+const workboxInfo = serviceWorkerInitiated.filter(([url, body]) => {
+  return workboxPattern.test(body);
+}).map(([url, body]) => {
+  return [url, Array.from(body.matchAll(workboxPattern)).map(([match]) => {
+    return match;
+  })];
+});
+
+return {
+  serviceWorkers: Object.fromEntries(serviceWorkers),
+  manifests: Object.fromEntries(manifests),
+  serviceWorkerInitiated: Object.fromEntries(serviceWorkerInitiated),
+  workboxInfo: Object.fromEntries(workboxInfo),
+  initiatorMap
+};


### PR DESCRIPTION
This is a custom metric that we can use as a workaround for the HTTP Archive response bodies being unavailable. It may also be useful for the [PWA chapter](https://github.com/HTTPArchive/almanac.httparchive.org/issues/2153) of the 2021 Web Almanac.

The process to get this data in and out of BigQuery is:

- merge this PR
- sync the WPT test server with this repo
- wait for the crawl to be completed
- query the `pages` dataset for the `_pwa` field in the HAR payload

Known issue: a page like https://developers.google.com/web/tools/chrome-user-experience-report/ installs a SW but its JS is so minified that there's no way to reliably parse the registration with a regex. I'd love to hear if there are better ways to detect which JS resource is a SW. (maybe we can borrow a technique from Lighthouse? cc @brendankenny)

Example WPT: https://www.webpagetest.org/result/210511_BiDc1V_ae6dbe0c19cd64c52b477fa46d3ab42a/?f=json

Output (addressable as `$.data.runs[1].firstView.pwa`):

```js
{
  "serviceWorkers": {
    "https://www.publicstorage.com/assets2019/sw.js": "importScripts(\"/static/precache-manifest.d35d3ddf878bb3d67c18641684395c87.js\", \"https://storage.googleapis.com/workbox-cdn/releases/3.6.3/workbox-sw.js\");\n\nif (workbox) {\r\n  workbox.skipWaiting();\r\n  workbox.clientsClaim();\r\n  \r\n  workbox.setConfig({ debug: true });\r\n  workbox.core.setLogLevel(workbox.core.LOG_LEVELS.debug);\r\n \r\n  workbox.routing.registerRoute('/help-center', workbox.strategies.networkFirst());\r\n\r\n  // Precache all files related to our webpack entries.\r\n  workbox.precaching.precacheAndRoute(self.__precacheManifest || [], { cleanUrls: false });\r\n  \r\n  //workbox.precaching.precacheAndRoute(['/'], { cleanUrls: false }); \r\n   \r\n  workbox.routing.registerRoute(/.*\\.(?:ashx|png|jpg|jpeg|svg|gif)/g, workbox.strategies.cacheFirst({ \r\n      cacheName: 'image-cache',\r\n  }));\r\n  \r\n  workbox.routing.registerRoute(new RegExp('^https://fonts.(?:googleapis|gstatic).com/(.*)'), workbox.strategies.cacheFirst());  \r\n  workbox.routing.registerRoute(new RegExp('/Fonts/.*\\.ttf'), workbox.strategies.cacheFirst());  \r\n}\n"
  },
  "manifests": {
    "https://www.publicstorage.com/static/manifest.json": {
      "icons": [
        {
          "src": "/static/icon_512x512.png",
          "sizes": "512x512",
          "type": "image/png"
        },
        {
          "src": "/static/icon_192x192.png",
          "sizes": "192x192",
          "type": "image/png"
        }
      ],
      "name": "Public Storage",
      "short_name": "ps.com",
      "orientation": "portrait",
      "display": "standalone",
      "start_url": "/?src=pwa",
      "description": "PublicStorage.com",
      "background_color": "#ffffff",
      "theme_color": "#ff6200"
    }
  },
  "serviceWorkerInitiated": [
    "https://www.publicstorage.com/assets2019/css/client.theme.9e6815b6a481b58a2af0.css",
    "https://www.publicstorage.com/Fonts/ITCAvantGardePro-Md.ttf",
    "https://www.publicstorage.com/Fonts/ps-icons-v2.woff",
    "https://www.publicstorage.com/assets2019/sw.js",
    "https://www.publicstorage.com/static/precache-manifest.d35d3ddf878bb3d67c18641684395c87.js",
    "https://storage.googleapis.com/workbox-cdn/releases/3.6.3/workbox-sw.js",
    "https://storage.googleapis.com/workbox-cdn/releases/3.6.3/workbox-core.dev.js",
    "https://storage.googleapis.com/workbox-cdn/releases/3.6.3/workbox-routing.dev.js",
    "https://storage.googleapis.com/workbox-cdn/releases/3.6.3/workbox-strategies.dev.js",
    "https://storage.googleapis.com/workbox-cdn/releases/3.6.3/workbox-precaching.dev.js",
    "https://www.publicstorage.com/assets2019/js/client.resaccess.0df8157e10d679ddcb30.min.js",
    "https://www.publicstorage.com/assets2019/js/client.usloc.0df8157e10d679ddcb30.min.js",
    "https://www.publicstorage.com/assets2019/css/client.rescreate.baedf7260b9b00c6147b.css",
    "https://www.publicstorage.com/assets2019/css/client.changepass.9b9bf8b059a126059b93.css",
    "https://www.publicstorage.com/assets2019/css/client.city.59e0f17ff453d5785b55.css",
    "https://www.publicstorage.com/assets2019/js/client.city.0df8157e10d679ddcb30.min.js",
    "https://www.publicstorage.com/assets2019/css/client.content.7c79871b0ee87dee8256.css",
    "https://www.publicstorage.com/assets2019/js/client.content.0df8157e10d679ddcb30.min.js",
    "https://www.publicstorage.com/assets2019/css/client.hc.1f191347da9e520967da.css",
    "https://www.publicstorage.com/assets2019/js/client.hc.0df8157e10d679ddcb30.min.js",
    "https://www.publicstorage.com/assets2019/css/client.home.af63b9dbacf3a86ab69a.css",
    "https://www.publicstorage.com/assets2019/js/client.home.0df8157e10d679ddcb30.min.js",
    "https://www.publicstorage.com/assets2019/css/client.properties.6ee67c15ce26f4cdc2f1.css",
    "https://www.publicstorage.com/assets2019/js/client.properties.0df8157e10d679ddcb30.min.js",
    "https://www.publicstorage.com/assets2019/css/client.registration.867dbc00c685f24a2eb5.css",
    "https://www.publicstorage.com/assets2019/js/client.registration.0df8157e10d679ddcb30.min.js",
    "https://www.publicstorage.com/assets2019/css/client.resaccess.ffbec641b4682d6ed85c.css",
    "https://www.publicstorage.com/assets2019/js/client.blog.0df8157e10d679ddcb30.min.js",
    "https://www.publicstorage.com/assets2019/js/client.changepass.0df8157e10d679ddcb30.min.js",
    "https://www.publicstorage.com/assets2019/js/client.rescreate.0df8157e10d679ddcb30.min.js",
    "https://www.publicstorage.com/assets2019/css/client.resdashboard.5f3aac2fbb509bc3a7a5.css",
    "https://www.publicstorage.com/assets2019/js/client.resdashboard.0df8157e10d679ddcb30.min.js",
    "https://www.publicstorage.com/assets2019/css/client.reseci.9d0e32303dbcaae49d2a.css",
    "https://www.publicstorage.com/assets2019/js/client.reseci.0df8157e10d679ddcb30.min.js",
    "https://www.publicstorage.com/assets2019/css/client.resretrieve.f3c2dddb035a855c4ee5.css",
    "https://www.publicstorage.com/assets2019/js/client.resretrieve.0df8157e10d679ddcb30.min.js",
    "https://www.publicstorage.com/assets2019/css/client.resstatus.ac1d59029b0b406ebac5.css",
    "https://www.publicstorage.com/assets2019/js/client.resstatus.0df8157e10d679ddcb30.min.js",
    "https://www.publicstorage.com/assets2019/css/client.search.67820d0192868975ef5f.css",
    "https://www.publicstorage.com/assets2019/js/client.search.0df8157e10d679ddcb30.min.js",
    "https://www.publicstorage.com/assets2019/js/client.theme.0df8157e10d679ddcb30.min.js",
    "https://www.publicstorage.com/assets2019/css/client.usloc.017dd1cdde68f266ca96.css",
    "https://www.publicstorage.com/assets2019/css/client.blog.1953d854b7543b90087d.css"
  ],
  "workboxInfo": {
    "https://www.publicstorage.com/assets2019/sw.js": [
      "workbox.skipWaiting",
      "workbox.clientsClaim",
      "workbox.setConfig",
      "workbox.core.setLogLevel",
      "workbox.core.LOG",
      "workbox.routing.registerRoute",
      "workbox.strategies.networkFirst",
      "workbox.precaching.precacheAndRoute",
      "workbox.precaching.precacheAndRoute",
      "workbox.routing.registerRoute",
      "workbox.strategies.cacheFirst",
      "workbox.routing.registerRoute",
      "workbox.strategies.cacheFirst",
      "workbox.routing.registerRoute",
      "workbox.strategies.cacheFirst"
    ],
    "https://storage.googleapis.com/workbox-cdn/releases/3.6.3/workbox-sw.js": [
      "workbox.v"
    ],
    "https://storage.googleapis.com/workbox-cdn/releases/3.6.3/workbox-core.dev.js": [
      "workbox.core",
      "workbox.v",
      "workbox.core.LOG",
      "workbox.core",
      "workbox.core",
      "workbox.core",
      "workbox.v",
      "workbox.v",
      "workbox.setConfig",
      "workbox.core.cacheNames",
      "workbox.core.setCacheNameDetails",
      "workbox.core.logLevel",
      "workbox.core.setLogLevel",
      "workbox.core.LOG"
    ],
    "https://storage.googleapis.com/workbox-cdn/releases/3.6.3/workbox-routing.dev.js": [
      "workbox.routing",
      "workbox.v",
      "workbox.routing",
      "workbox.routing.Route",
      "workbox.routing.Route",
      "workbox.routing.Route",
      "workbox.routing",
      "workbox.routing.Route",
      "workbox.routing.Route",
      "workbox.routing.Route",
      "workbox.routing.Route",
      "workbox.routing",
      "workbox.routing.Route",
      "workbox.routing.Route",
      "workbox.routing.Route",
      "workbox.routing.Route",
      "workbox.routing.Route",
      "workbox.routing",
      "workbox.routing.Route",
      "workbox.routing.Route",
      "workbox.routing.Router",
      "workbox.routing.Route",
      "workbox.routing.Route",
      "workbox.routing.Route",
      "workbox.routing.Route",
      "workbox.routing.registerRoute",
      "workbox.routing.NavigationRoute",
      "workbox.routing.Router",
      "workbox.core.cacheNames",
      "workbox.routing.NavigationRoute",
      "workbox.routing.registerNavigationRoute",
      "workbox.core.",
      "workbox.core.",
      "workbox.core.",
      "workbox.core.",
      "workbox.core."
    ],
    "https://storage.googleapis.com/workbox-cdn/releases/3.6.3/workbox-strategies.dev.js": [
      "workbox.strategies",
      "workbox.v",
      "workbox.strategies",
      "workbox.core.cacheNames",
      "workbox.routing.Router",
      "workbox.routing.Router",
      "workbox.strategies",
      "workbox.core.cacheNames",
      "workbox.routing.Router",
      "workbox.routing.Router",
      "workbox.strategies",
      "workbox.core.cacheNames",
      "workbox.routing.Router",
      "workbox.routing.Router",
      "workbox.strategies",
      "workbox.core.cacheNames",
      "workbox.routing.Router",
      "workbox.routing.Router",
      "workbox.strategies",
      "workbox.core.cacheNames",
      "workbox.routing.Router",
      "workbox.routing.Router",
      "workbox.strategies.cacheFirst",
      "workbox.strategies.CacheFirst",
      "workbox.strategies.cacheOnly",
      "workbox.strategies.CacheOnly",
      "workbox.strategies.networkFirst",
      "workbox.strategies.NetworkFirst",
      "workbox.strategies.networkOnly",
      "workbox.strategies.NetworkOnly",
      "workbox.strategies.staleWhileRevalidate",
      "workbox.strategies.StaleWhileRevalidate",
      "workbox.core.",
      "workbox.core.",
      "workbox.core.",
      "workbox.core.",
      "workbox.core.",
      "workbox.core."
    ],
    "https://storage.googleapis.com/workbox-cdn/releases/3.6.3/workbox-precaching.dev.js": [
      "workbox.precaching",
      "workbox.v",
      "workbox.precaching",
      "workbox.precaching.InstallResult",
      "workbox.precaching.CleanupResult",
      "workbox.precaching.CleanupResult",
      "workbox.precaching.precache",
      "workbox.precaching",
      "workbox.precaching.addRoute",
      "workbox.precaching.precacheAndRoute",
      "workbox.precaching.suppressWarnings",
      "workbox.precaching.addPlugins",
      "workbox.core.",
      "workbox.core.",
      "workbox.core.",
      "workbox.core.",
      "workbox.core.",
      "workbox.core.",
      "workbox.core.",
      "workbox.core."
    ]
  }
}
```