### PR TITLE
New script to detect importScripts(), service worker events and service worker properties

### DIFF
--- a/custom_metrics/pwa.js
+++ b/custom_metrics/pwa.js
@@ -70,11 +70,13 @@ const serviceWorkerInitiatedURLs = new Set(Array.from(serviceWorkerURLs).flatMap
 const serviceWorkerInitiated = getEntriesForURLs(serviceWorkerInitiatedURLs);
 
 // We should use serviceWorkerInitiatedURLs here, but SW detection has some false negatives.
-function getInfoForPattern(regexPattern) {
+function getInfoForPattern(regexPattern, extractMatchingGroupOnly) {
   return response_bodies.filter(har => {
     return regexPattern.test(har.response_body);
   }).map(har => {
-    return [har.url, Array.from(har.response_body.matchAll(regexPattern)).map(m => m[0])];
+    return [har.url, Array.from(har.response_body.matchAll(regexPattern)).map(m => {
+      return extractMatchingGroupOnly ? m[1] : m[0]
+    })];
   });
 }
 
@@ -85,10 +87,10 @@ const importScriptsPattern = /importScripts\(.*\);/g;
 const importScriptsInfo = getInfoForPattern(importScriptsPattern);
 
 const swEventListenersPattern = /addEventListener\(\s*[\'"](install|activate|fetch|push|notificationclick|notificationclose|sync|canmakepayment|paymentrequest|message|messageerror|periodicsync|backgroundfetchsuccess|backgroundfetchfailure|backgroundfetchabort|backgroundfetchclick)[\'"]/g;
-const swEventListenersInfo = getInfoForPattern(swEventListenersPattern);
+const swEventListenersInfo = getInfoForPattern(swEventListenersPattern, true);
 
 const swPropertiesPattern = /\.on(install|activate|fetch|push|notificationclick|notificationclose|sync|canmakepayment|paymentrequest|message|messageerror|periodicsync|backgroundfetchsuccess|backgroundfetchfailure|backgroundfetchabort|backgroundfetchclick)\s*=/g;
-const swPropertiesInfo = getInfoForPattern(swPropertiesPattern);
+const swPropertiesInfo = getInfoForPattern(swPropertiesPattern, true);
 
 const swMethodsPattern = /skipWaiting\(\)|navigationPreload.(enable|disable|setHeaderValue|getState)/g;
 const swMethodsInfo = getInfoForPattern(swMethodsPattern);

--- a/custom_metrics/pwa.js
+++ b/custom_metrics/pwa.js
@@ -107,6 +107,10 @@ const windowEventListenersInfo = getInfoForPattern(windowEventListenersPattern, 
 const windowPropertiesPattern = /\.on(appinstalled|beforeinstallprompt)\s*=/g;
 const windowPropertiesInfo = getInfoForPattern(windowPropertiesPattern, true);
 
+function isObjectKeyEmpty(field) {
+  return field == null || field.length == 0;
+}
+
 return {
   serviceWorkers: Object.fromEntries(serviceWorkers),
   manifests: Object.fromEntries(manifests),
@@ -119,5 +123,7 @@ return {
   swObjectsInfo: Object.fromEntries(swObjectsInfo),
   swRegistrationPropertiesInfo: Object.fromEntries(swRegistrationPropertiesInfo),
   windowEventListenersInfo: Object.fromEntries(windowEventListenersInfo),
-  windowPropertiesInfo: Object.fromEntries(windowPropertiesInfo)
+  windowPropertiesInfo: Object.fromEntries(windowPropertiesInfo),
+  //Experimental field: Heuristic to detect if a site has a service worker even if the 'serviceWorkers' field is empty (false positives).
+  serviceWorkerHeuristic: !isObjectKeyEmpty(serviceWorkers) || !isObjectKeyEmpty(workboxInfo) || !isObjectKeyEmpty(importScriptsInfo) || !isObjectKeyEmpty(swEventListenersInfo) || !isObjectKeyEmpty(swMethodsInfo)
 };

--- a/custom_metrics/pwa.js
+++ b/custom_metrics/pwa.js
@@ -90,6 +90,12 @@ const swEventListenersInfo = getInfoForPattern(swEventListenersPattern);
 const swPropertiesPattern = /\.on(install|activate|fetch|push|notificationclick|notificationclose|sync|canmakepayment|paymentrequest|message|messageerror|periodicsync|backgroundfetchsuccess|backgroundfetchfailure|backgroundfetchabort|backgroundfetchclick)\s*=/g;
 const swPropertiesInfo = getInfoForPattern(swPropertiesPattern);
 
+const swMethodsPattern = /skipWaiting\(\)|navigationPreload.(enable|disable|setHeaderValue|getState)/g;
+const swMethodsInfo = getInfoForPattern(swMethodsPattern);
+
+const swObjectsPattern = /clients\.(get|matchAll|openWindow|claim)|client\.(postMessage|id|type|url)|caches\.(match|has|open|delete|keys)|cache\.(match|matchAll|add|addAll|put|keys)/g;
+const swObjectsInfo = getInfoForPattern(swObjectsPattern);
+
 return {
   serviceWorkers: Object.fromEntries(serviceWorkers),
   manifests: Object.fromEntries(manifests),
@@ -97,5 +103,7 @@ return {
   workboxInfo: Object.fromEntries(workboxInfo),
   importScriptsInfo: Object.fromEntries(importScriptsInfo),
   swEventListenersInfo: Object.fromEntries(swEventListenersInfo),
-  swPropertiesInfo: Object.fromEntries(swPropertiesInfo)
+  swPropertiesInfo: Object.fromEntries(swPropertiesInfo),
+  swMethodsInfo: Object.fromEntries(swMethodsInfo),
+  swObjectsInfo: Object.fromEntries(swObjectsInfo)
 };

--- a/custom_metrics/pwa.js
+++ b/custom_metrics/pwa.js
@@ -75,7 +75,7 @@ function getInfoForPattern(regexPattern, extractMatchingGroupOnly) {
     return regexPattern.test(har.response_body);
   }).map(har => {
     return [har.url, Array.from(har.response_body.matchAll(regexPattern)).map(m => {
-      return extractMatchingGroupOnly ? m[1] : m[0]
+      return (extractMatchingGroupOnly && m.length > 0) ? m[1] : m[0]
     })];
   });
 }
@@ -83,8 +83,8 @@ function getInfoForPattern(regexPattern, extractMatchingGroupOnly) {
 const workboxPattern = /(?:workbox:[a-z\-]+:[\d.]+|workbox\.[a-zA-Z]+\.?[a-zA-Z]*)/g;
 const workboxInfo = getInfoForPattern(workboxPattern);
 
-const importScriptsPattern = /importScripts\(.*\);/g;
-const importScriptsInfo = getInfoForPattern(importScriptsPattern);
+const importScriptsPattern = /importScripts\(([^)]*)\)/g;
+const importScriptsInfo = getInfoForPattern(importScriptsPattern, true);
 
 const swEventListenersPattern = /addEventListener\(\s*[\'"](install|activate|fetch|push|notificationclick|notificationclose|sync|canmakepayment|paymentrequest|message|messageerror|periodicsync|backgroundfetchsuccess|backgroundfetchfailure|backgroundfetchabort|backgroundfetchclick)[\'"]/g;
 const swEventListenersInfo = getInfoForPattern(swEventListenersPattern, true);

--- a/custom_metrics/pwa.js
+++ b/custom_metrics/pwa.js
@@ -77,9 +77,33 @@ const workboxInfo = response_bodies.filter(har => {
   return [har.url, Array.from(har.response_body.matchAll(workboxPattern)).map(m => m[0])];
 });
 
+const importScriptsPattern = /importScripts\(.*\);/g;
+const importScriptsInfo = response_bodies.filter(har => {
+  return importScriptsPattern.test(har.response_body);
+}).map(har => {
+  return [har.url, Array.from(har.response_body.matchAll(importScriptsPattern)).map(m => m[0])];
+});
+
+const swEventListenersPattern = /addEventListener\(\s*[\'"](install|activate|fetch|push|notificationclick|notificationclose|sync|canmakepayment|paymentrequest|message|messageerror|periodicsync|backgroundfetchsuccess|backgroundfetchfailure|backgroundfetchabort|backgroundfetchclick)[\'"]/g;
+const swEventListenersInfo = response_bodies.filter(har => {
+  return swEventListenersPattern.test(har.response_body);
+}).map(har => {
+  return [har.url, Array.from(har.response_body.matchAll(swEventListenersPattern)).map(m => m[0])];
+});
+
+const swPropertiesPattern = /\.on(install|activate|fetch|push|notificationclick|notificationclose|sync|canmakepayment|paymentrequest|message|messageerror|periodicsync|backgroundfetchsuccess|backgroundfetchfailure|backgroundfetchabort|backgroundfetchclick)\s*=/g;
+const wPropertiesInfo = response_bodies.filter(har => {
+  return swEventListenersPattern.test(har.response_body);
+}).map(har => {
+  return [har.url, Array.from(har.response_body.matchAll(swPropertiesPattern)).map(m => m[0])];
+});
+
 return {
   serviceWorkers: Object.fromEntries(serviceWorkers),
   manifests: Object.fromEntries(manifests),
   serviceWorkerInitiated: Object.keys(Object.fromEntries(serviceWorkerInitiated)),
-  workboxInfo: Object.fromEntries(workboxInfo)
+  workboxInfo: Object.fromEntries(workboxInfo),
+  importScriptsInfo: Object.fromEntries(importScriptsInfo),
+  swEventListenersInfo: Object.fromEntries(swEventListenersInfo),
+  wPropertiesInfo: Object.fromEntries(wPropertiesInfo)
 };

--- a/custom_metrics/pwa.js
+++ b/custom_metrics/pwa.js
@@ -69,34 +69,26 @@ const manifests = getEntriesForURLs(manifestURLs).map(([url, body]) => {
 const serviceWorkerInitiatedURLs = new Set(Array.from(serviceWorkerURLs).flatMap(getURLsInitiatedBy));
 const serviceWorkerInitiated = getEntriesForURLs(serviceWorkerInitiatedURLs);
 
-const workboxPattern = /(?:workbox:[a-z\-]+:[\d.]+|workbox\.[a-zA-Z]+\.?[a-zA-Z]*)/g;
 // We should use serviceWorkerInitiatedURLs here, but SW detection has some false negatives.
-const workboxInfo = response_bodies.filter(har => {
-  return workboxPattern.test(har.response_body);
-}).map(har => {
-  return [har.url, Array.from(har.response_body.matchAll(workboxPattern)).map(m => m[0])];
-});
+function getInfoForPattern(regexPattern) {
+  return response_bodies.filter(har => {
+    return regexPattern.test(har.response_body);
+  }).map(har => {
+    return [har.url, Array.from(har.response_body.matchAll(regexPattern)).map(m => m[0])];
+  });
+}
+
+const workboxPattern = /(?:workbox:[a-z\-]+:[\d.]+|workbox\.[a-zA-Z]+\.?[a-zA-Z]*)/g;
+const workboxInfo = getInfoForPattern(workboxPattern);
 
 const importScriptsPattern = /importScripts\(.*\);/g;
-const importScriptsInfo = response_bodies.filter(har => {
-  return importScriptsPattern.test(har.response_body);
-}).map(har => {
-  return [har.url, Array.from(har.response_body.matchAll(importScriptsPattern)).map(m => m[0])];
-});
+const importScriptsInfo = getInfoForPattern(importScriptsPattern);
 
 const swEventListenersPattern = /addEventListener\(\s*[\'"](install|activate|fetch|push|notificationclick|notificationclose|sync|canmakepayment|paymentrequest|message|messageerror|periodicsync|backgroundfetchsuccess|backgroundfetchfailure|backgroundfetchabort|backgroundfetchclick)[\'"]/g;
-const swEventListenersInfo = response_bodies.filter(har => {
-  return swEventListenersPattern.test(har.response_body);
-}).map(har => {
-  return [har.url, Array.from(har.response_body.matchAll(swEventListenersPattern)).map(m => m[0])];
-});
+const swEventListenersInfo = getInfoForPattern(swEventListenersPattern);
 
 const swPropertiesPattern = /\.on(install|activate|fetch|push|notificationclick|notificationclose|sync|canmakepayment|paymentrequest|message|messageerror|periodicsync|backgroundfetchsuccess|backgroundfetchfailure|backgroundfetchabort|backgroundfetchclick)\s*=/g;
-const wPropertiesInfo = response_bodies.filter(har => {
-  return swEventListenersPattern.test(har.response_body);
-}).map(har => {
-  return [har.url, Array.from(har.response_body.matchAll(swPropertiesPattern)).map(m => m[0])];
-});
+const wPropertiesInfo = getInfoForPattern(swPropertiesPattern);
 
 return {
   serviceWorkers: Object.fromEntries(serviceWorkers),

--- a/custom_metrics/pwa.js
+++ b/custom_metrics/pwa.js
@@ -125,5 +125,5 @@ return {
   windowEventListenersInfo: Object.fromEntries(windowEventListenersInfo),
   windowPropertiesInfo: Object.fromEntries(windowPropertiesInfo),
   //Experimental field: Heuristic to detect if a site has a service worker even if the 'serviceWorkers' field is empty (false positives).
-  serviceWorkerHeuristic: !isObjectKeyEmpty(serviceWorkers) || !isObjectKeyEmpty(workboxInfo) || !isObjectKeyEmpty(importScriptsInfo) || !isObjectKeyEmpty(swEventListenersInfo) || !isObjectKeyEmpty(swMethodsInfo)
+  serviceWorkerHeuristic: !isObjectKeyEmpty(serviceWorkers) || !isObjectKeyEmpty(workboxInfo) || !isObjectKeyEmpty(swEventListenersInfo) || !isObjectKeyEmpty(swMethodsInfo)
 };

--- a/custom_metrics/pwa.js
+++ b/custom_metrics/pwa.js
@@ -86,17 +86,26 @@ const workboxInfo = getInfoForPattern(workboxPattern);
 const importScriptsPattern = /importScripts\(([^)]*)\)/g;
 const importScriptsInfo = getInfoForPattern(importScriptsPattern, true);
 
-const swEventListenersPattern = /addEventListener\(\s*[\'"](install|activate|fetch|push|notificationclick|notificationclose|sync|canmakepayment|paymentrequest|message|messageerror|periodicsync|backgroundfetchsuccess|backgroundfetchfailure|backgroundfetchabort|backgroundfetchclick)[\'"]/g;
+const swEventListenersPattern = /addEventListener\(\s*[\'"](install|activate|push|notificationclick|notificationclose|sync|canmakepayment|paymentrequest|periodicsync|backgroundfetchsuccess|backgroundfetchfailure|backgroundfetchabort|backgroundfetchclick)[\'"]/g;
 const swEventListenersInfo = getInfoForPattern(swEventListenersPattern, true);
 
-const swPropertiesPattern = /\.on(install|activate|fetch|push|notificationclick|notificationclose|sync|canmakepayment|paymentrequest|message|messageerror|periodicsync|backgroundfetchsuccess|backgroundfetchfailure|backgroundfetchabort|backgroundfetchclick)\s*=/g;
+const swPropertiesPattern = /\.on(install|activate|push|notificationclick|notificationclose|sync|canmakepayment|paymentrequest|periodicsync|backgroundfetchsuccess|backgroundfetchfailure|backgroundfetchabort|backgroundfetchclick)\s*=/g;
 const swPropertiesInfo = getInfoForPattern(swPropertiesPattern, true);
 
-const swMethodsPattern = /skipWaiting\(\)|navigationPreload.(enable|disable|setHeaderValue|getState)/g;
+const swMethodsPattern = /skipWaiting\(\)/g;
 const swMethodsInfo = getInfoForPattern(swMethodsPattern);
 
 const swObjectsPattern = /clients\.(get|matchAll|openWindow|claim)|client\.(postMessage|id|type|url)|caches\.(match|has|open|delete|keys)|cache\.(match|matchAll|add|addAll|put|keys)/g;
 const swObjectsInfo = getInfoForPattern(swObjectsPattern);
+
+const swRegistrationPropertiesPattern = /navigationPreload\.(enable|disable|setHeaderValue|getState)|pushManager\.(getSubscription|permissionState|subscribe)|sync\.(register|getTags)/g;
+const swRegistrationPropertiesInfo = getInfoForPattern(swRegistrationPropertiesPattern);
+
+const windowEventListenersPattern = /addEventListener\(\s*[\'"](appinstalled|beforeinstallprompt)[\'"]/g;
+const windowEventListenersInfo = getInfoForPattern(windowEventListenersPattern, true);
+
+const windowPropertiesPattern = /\.on(appinstalled|beforeinstallprompt)\s*=/g;
+const windowPropertiesInfo = getInfoForPattern(windowPropertiesPattern, true);
 
 return {
   serviceWorkers: Object.fromEntries(serviceWorkers),
@@ -107,5 +116,8 @@ return {
   swEventListenersInfo: Object.fromEntries(swEventListenersInfo),
   swPropertiesInfo: Object.fromEntries(swPropertiesInfo),
   swMethodsInfo: Object.fromEntries(swMethodsInfo),
-  swObjectsInfo: Object.fromEntries(swObjectsInfo)
+  swObjectsInfo: Object.fromEntries(swObjectsInfo),
+  swRegistrationPropertiesInfo: Object.fromEntries(swRegistrationPropertiesInfo),
+  windowEventListenersInfo: Object.fromEntries(windowEventListenersInfo),
+  windowPropertiesInfo: Object.fromEntries(windowPropertiesInfo)
 };

--- a/custom_metrics/pwa.js
+++ b/custom_metrics/pwa.js
@@ -88,7 +88,7 @@ const swEventListenersPattern = /addEventListener\(\s*[\'"](install|activate|fet
 const swEventListenersInfo = getInfoForPattern(swEventListenersPattern);
 
 const swPropertiesPattern = /\.on(install|activate|fetch|push|notificationclick|notificationclose|sync|canmakepayment|paymentrequest|message|messageerror|periodicsync|backgroundfetchsuccess|backgroundfetchfailure|backgroundfetchabort|backgroundfetchclick)\s*=/g;
-const wPropertiesInfo = getInfoForPattern(swPropertiesPattern);
+const swPropertiesInfo = getInfoForPattern(swPropertiesPattern);
 
 return {
   serviceWorkers: Object.fromEntries(serviceWorkers),
@@ -97,5 +97,5 @@ return {
   workboxInfo: Object.fromEntries(workboxInfo),
   importScriptsInfo: Object.fromEntries(importScriptsInfo),
   swEventListenersInfo: Object.fromEntries(swEventListenersInfo),
-  wPropertiesInfo: Object.fromEntries(wPropertiesInfo)
+  swPropertiesInfo: Object.fromEntries(swPropertiesInfo)
 };


### PR DESCRIPTION
Hi folks,

As discussed in #203 I decided to create a PR for this script (even when is not optimal), since, after analyzing some tests with @tunetheweb, having it merged for Monday's crawl could help us get an idea of the number of false negatives in `serviceWorkerInitiatedURLs`.

We have added three new fields to the response: `importScriptsInfo`, `swEventListenersInfo`, `wPropertiesInfo`, which use [Rick's script for Workbox detection](https://github.com/HTTPArchive/legacy.httparchive.org/blob/a6b419f65194abb81840be6e52cfbaedfb945b40/custom_metrics/pwa.js#L72) and combines it with the regular expressions used last year to detect SW events and properties ([sw_events.sql](https://github.com/HTTPArchive/almanac.httparchive.org/blob/a883df882114af3b641791f787c3359bede5d803/sql/2020/pwa/sw_events.sql#L15)), plus a new one to detect calls to `importScripts()`.

### Tests

- Here is a [test](https://www.webpagetest.org/result/210530_AiDcS8_e2a3c376a59afc821bf38a203c510922/?f=json) for https://www.naranja.com. In this case the `serviceWorkers` field is non-empty and it also has values for the new properties.
- Here is another [test](https://www.webpagetest.org/result/210530_AiDcX2_781fbed981df2fb15d8270d9800afebf/?f=json) for https://mobile.twitter.com, where the `serviceWorkers` is empty, but we can see `swEventListenersInfo` and `wPropertiesInfo` populated.

It would be interesting to see how many cases like Twitter we have, to see if we are under-counting many sites that use service workers.

From what we could check with @tunetheweb this number represent a very small percentage.

It would be great if @rviscomi or @jeffposnick can take a look at some point.

cc // @obto