### PR TITLE
Measure decoding attribute of images

### DIFF
--- a/custom_metrics/Images.js
+++ b/custom_metrics/Images.js
@@ -17,7 +17,8 @@ var wptImages = function(win) {
             naturalWidth: el.naturalWidth,
             naturalHeight: el.naturalHeight,
             loading: el.getAttribute("loading"),
-            "in-viewport": el.getBoundingClientRect().top < window.innerHeight,
+            decoding: el.getAttribute("decoding"),
+            inViewport: el.getBoundingClientRect().top < window.innerHeight,
           });
         }
       }


### PR DESCRIPTION
Track adoption of `decoding=async` attributes on images. This will be especially interesting to analyze in conjunction with the `inViewport` property, which I renamed to camelCase for consistency with other properties.

cc @kevinfarrugia 