### PR TITLE
Improved lazy in viewport

### DIFF
--- a/custom_metrics/Images.js
+++ b/custom_metrics/Images.js
@@ -1,4 +1,4 @@
-var wptImages = function(win) {
+var wptImages = function (win) {
   var images = [];
   if (win) {
     var doc = win.document;
@@ -18,7 +18,11 @@ var wptImages = function(win) {
             naturalHeight: el.naturalHeight,
             loading: el.getAttribute("loading"),
             decoding: el.getAttribute("decoding"),
-            inViewport: el.getBoundingClientRect().top < window.innerHeight,
+            inViewport:
+              el.getBoundingClientRect().bottom >= 0 &&
+              el.getBoundingClientRect().right >= 0 &&
+              el.getBoundingClientRect().top <= window.innerHeight &&
+              el.getBoundingClientRect().left <= window.innerWidth,
           });
         }
       }
@@ -28,10 +32,9 @@ var wptImages = function(win) {
           if (im && im.length) {
             images = images.concat(im);
           }
-        } catch(e) {}
+        } catch (e) {}
       }
-      if (images.length > 10000)
-        break;
+      if (images.length > 10000) break;
     }
   }
   return images;

--- a/custom_metrics/metric-summary.md
+++ b/custom_metrics/metric-summary.md
@@ -704,3 +704,21 @@ Example response:
 ```json
 [5, 12, 11]
 ```
+
+# [Images.js](https://github.com/HTTPArchive/legacy.httparchive.org/blob/master/custom_metrics/Images.js) metrics
+
+A JSON array of `<img>` elements on the page.
+
+Sample response:
+
+```
+  {
+    "url": "https://placekitten.com/401/401",
+    "width": 401,
+    "height": 401,
+    "naturalWidth": 401,
+    "naturalHeight": 401,
+    "loading": "lazy",
+    "inViewport": true
+  }
+```


### PR DESCRIPTION
Updated the Images custom metric `inViewport` property to check if the image is within the viewport, compared to simply checking the `top` position.

Will be used in 2021 Resource Hints chapter.

Reference discussion: https://github.com/HTTPArchive/legacy.httparchive.org/pull/202#discussion_r647905245

I opted against using the `IntersectionObserver` because its `async` nature would add unnecessary complexity to the custom metric. Ultimately we want to return `true` if the image is in the visible viewport and do not need to monitor for changes resulting from scroll events.

**Sample WPT**
https://webpagetest.org/custom_metrics.php?test=210614_AiDcH0_5d6b574017a022b085beade79bf0deef&run=1&cached=0

```
[
  {
    "url": "https://placekitten.com/101/101",
    "width": 101,
    "height": 101,
    "naturalWidth": 101,
    "naturalHeight": 101,
    "loading": "lazy",
    "in-viewport": true
  },
  {
    "url": "https://placekitten.com/102/102",
    "width": 102,
    "height": 102,
    "naturalWidth": 102,
    "naturalHeight": 102,
    "loading": "lazy",
    "in-viewport": false
  }
]
```