### PR TITLE
New A11Y metrics

### DIFF
--- a/custom_metrics/a11y.js
+++ b/custom_metrics/a11y.js
@@ -267,12 +267,21 @@ return JSON.stringify({
       }
 
       for (let source of node.name.sources || []) {
-        // Bubble up the final value. By default its nested inside
-        if (source.value) {
-          source.value = source.value.value;
+        // Only include sources that contributed a value
+        if (!source.value || !source.value.value) {
+          continue;
         }
 
-        accessible_name_sources.push(source);
+        // Only keep the relevant properties
+        const cleaned_source = {
+          type: source.type,
+          value: source.value.value,
+        };
+        if (source.attribute) {
+          cleaned_source.attribute = source.attribute;
+        }
+
+        control_stats.accessible_name_sources.push(cleaned_source);
       }
 
       accumulator.push(control_stats);
@@ -292,7 +301,7 @@ return JSON.stringify({
         continue;
       }
 
-      addControlToStats(node, controls);
+      addControlToStats(node, stats_of_controls);
     }
 
     return stats_of_controls;
@@ -304,10 +313,13 @@ return JSON.stringify({
     const fieldset_stats = [];
 
     const fieldset_elements = document.querySelectorAll('fieldset');
-    for (let fieldset of fieldsets) {
-      let has_legend = fieldset.querySelector('legend');
+    for (let fieldset of fieldset_elements) {
+      let has_legend = !!fieldset.querySelector('legend');
       const total_radio = fieldset.querySelectorAll('input[type="radio"]').length
       const total_checkbox = fieldset.querySelectorAll('input[type="checkbox"]').length
+
+      total_radio_in_fieldset += total_radio;
+      total_checkbox_in_fieldset += total_checkbox;
 
       fieldset_stats.push({
         has_legend,

--- a/custom_metrics/a11y.js
+++ b/custom_metrics/a11y.js
@@ -1,6 +1,9 @@
 //[a11y]
 // Uncomment the previous line for testing on webpagetest.org
 
+// Create a reference to $WPT_ACCESSIBILITY_TREE. This makes it easier to replace or make any modifications to it in the future
+const WPT_ACCESSIBILITY_TREE = $WPT_ACCESSIBILITY_TREE;
+
 function incrementCollectorKey(collector, key) {
   if (!collector[key]) {
     collector[key] = 1;
@@ -211,37 +214,7 @@ return JSON.stringify({
     return document.querySelectorAll('.sr-only, .visually-hidden').length > 0;
   }),
   form_control_a11y_tree: captureAndLogError(() => {
-    function doesMatchAny(string, regexps) {
-      let found = false;
-      for (const regexp of regexps) {
-        if (regexp.test(string)) {
-          return true;
-        }
-      }
-
-      return false;
-    }
-
-    const attributes_to_track = [
-      /^aria-.+$/,
-      /^type$/,
-      /^id$/,
-      /^name$/,
-      /^placeholder$/,
-      /^accept$/,
-      /^autocomplete$/,
-      /^autofocus$/,
-      /^capture$/,
-      /^max$/,
-      /^maxlength$/,
-      /^min$/,
-      /^minlength$/,
-      /^required$/,
-      /^readonly$/,
-      /^pattern$/,
-      /^multiple$/,
-      /^step$/,
-    ];
+    const attributes_to_track_regex = /^(aria-.+|type|id|name|placeholder|accept|autocomplete|autofocus|capture|max|maxlength|min|minlength|required|readonly|pattern|multiple|step)$/i;
     function addControlToStats(node, accumulator) {
       const control_stats = {
         type: node.node_info.nodeType.toLowerCase(),
@@ -255,7 +228,7 @@ return JSON.stringify({
       // Store all attribute information
       for (let [key, value] of Object.entries(node.node_info.attributes || {})) {
         key = key.toLowerCase();
-        if (!doesMatchAny(key, attributes_to_track)) {
+        if (!attributes_to_track_regex.test(key)) {
           continue;
         }
 
@@ -295,7 +268,7 @@ return JSON.stringify({
     ];
 
     const stats_of_controls = [];
-    for (const node of $WPT_ACCESSIBILITY_TREE) {
+    for (const node of WPT_ACCESSIBILITY_TREE) {
       const node_type = (node.node_info?.nodeType || '').toLowerCase();
       if (!allowed_control_types.includes(node_type)) {
         continue;

--- a/custom_metrics/a11y.js
+++ b/custom_metrics/a11y.js
@@ -362,11 +362,7 @@ return JSON.stringify({
         return false;
       }
 
-      if (label.substr(0, 1) === '*' || label.substr(-1, 1) === '*') {
-        return true;
-      }
-
-      return false;
+      return label.startsWith('*') || label.endsWith('*');
     }
 
     const controls = document.querySelectorAll('input, select, textarea');

--- a/custom_metrics/almanac.js
+++ b/custom_metrics/almanac.js
@@ -601,6 +601,39 @@ return JSON.stringify({
     return parsed_videos;
   })(),
 
+  'audios': (() => {
+    const audios = document.querySelectorAll('audio');
+    const tracks = document.querySelectorAll('audio track');
+
+    const filter_options = {
+      include_only_prop_list: [
+        /^autoplay$/,
+        /^controls$/,
+        /^loop$/,
+        /^muted$/,
+        /^poster$/,
+        /^preload$/,
+        /^aria-.+$/,
+      ],
+      // Protect us from weird values
+      max_prop_length: 255,
+    };
+    const parsed_audios = parseNodes(audios, filter_options);
+
+    // Count the number of audio elements that have a track element
+    let total_audios_with_track_element = 0;
+    for (let audio of audios) {
+      if (audio.querySelector('track')) {
+        total_audios_with_track_element++;
+      }
+    }
+
+    const parsed_tracks = parseNodes(tracks, {max_prop_length: 255});
+    parsed_audios.total_with_track = total_audios_with_track_element;
+    parsed_audios.tracks = parsed_tracks;
+    return parsed_audios;
+  })(),
+
   'iframes': (() => {
     const iframes = document.querySelectorAll("iframe");
     const iframes_using_loading = [

--- a/custom_metrics/almanac.js
+++ b/custom_metrics/almanac.js
@@ -587,7 +587,16 @@ return JSON.stringify({
     };
     const parsed_videos = parseNodes(videos, filter_options);
 
+    // Count the number of video elements that have a track element
+    let total_videos_with_track_element = 0;
+    for (let video of videos) {
+      if (video.querySelector('track')) {
+        total_videos_with_track_element++;
+      }
+    }
+
     const parsed_tracks = parseNodes(tracks, {max_prop_length: 255});
+    parsed_videos.total_with_track = total_videos_with_track_element;
     parsed_videos.tracks = parsed_tracks;
     return parsed_videos;
   })(),
@@ -597,11 +606,11 @@ return JSON.stringify({
     const iframes_using_loading = [
       ...document.querySelectorAll("iframe[loading]"),
     ];
-  
+
     /** @type {ParseNodeOptions} */
     return {
       iframes: parseNodes(iframes),
-  
+
       loading_values: iframes_using_loading.map((iframe) => {
         const value = iframe.getAttribute("loading") || "";
         return value.toLocaleLowerCase().replace(/\s+/gm, " ").trim();

--- a/custom_metrics/metric-summary.md
+++ b/custom_metrics/metric-summary.md
@@ -414,6 +414,8 @@ Example response:
 
 Stats of `<video>` and `<track>` elements.
 
+`total_with_track` contains the total number of `<video>` elements had at least one `<track>` element
+
 Example response:
 
 ```json
@@ -432,6 +434,7 @@ Example response:
     "poster": 1,
     "src": 1
   },
+  "total_with_track": 1,
   "tracks": {
     "total": 0,
     "nodes": [],

--- a/custom_metrics/metric-summary.md
+++ b/custom_metrics/metric-summary.md
@@ -715,13 +715,13 @@ A JSON array of `<img>` elements on the page.
 Sample response:
 
 ```
-  {
-    "url": "https://placekitten.com/401/401",
-    "width": 401,
-    "height": 401,
-    "naturalWidth": 401,
-    "naturalHeight": 401,
-    "loading": "lazy",
-    "inViewport": true
-  }
+{
+  "url": "https://placekitten.com/401/401",
+  "width": 401,
+  "height": 401,
+  "naturalWidth": 401,
+  "naturalHeight": 401,
+  "loading": "lazy",
+  "inViewport": true
+}
 ```


### PR DESCRIPTION
Progress on https://github.com/HTTPArchive/almanac.httparchive.org/issues/2147

This PR adds five new metrics:

1. `form_control_a11y_tree`: A slimmed down version of the browser accessibility tree for form controls (select, input, textarea, buttons)
2. `fieldset_radio_checkbox`: Documents how many radios and checkboxes there are. Then checks how many of those inputs are correctly placed in a fieldset with a legend
3. `required_form_controls`: Scans for all the required form controls on the page. Looks for `required`, `aria-required`, or an asterisk at the start or end of the visible label
4. Track `<audio>` elements and their `<track>`s
5. Addition of a `total_with_track` metric to the `videos` section in almanac.js

This code has been tested on custom built pages ([example](https://output.jsbin.com/ziwubinatu/1)) and amazon.com (stress test for large amounts of elements) and passed the tests.

[Amazon.com test](https://www.webpagetest.org/custom_metrics.php?test=210627_AiDc7T_04ad325e19e194b517da98f2e38bc2cb&run=1&cached=0)

[Custom page test](https://www.webpagetest.org/result/210627_BiDc2P_3c5bf0159172753a230ea9e6895f0fd8/)