### PR TITLE
New mobile web metric

### DIFF
--- a/custom_metrics/almanac.js
+++ b/custom_metrics/almanac.js
@@ -424,6 +424,33 @@ return JSON.stringify({
 
     return inputNodes;
   })(),
+  'link_protocols_used': (() => {
+    const protocols_and_count = {};
+    const anchors = document.querySelectorAll('a[href]');
+    for (const anchor of anchors) {
+      try {
+        const url = new URL(anchor.href);
+
+        // Get the protocol and remove the :
+        const protocol = (url.protocol || '').toLowerCase().slice(0, -1);
+        if (!protocol) {
+          continue;
+        }
+
+        // Increase the counter
+        if (protocols_and_count[protocol]) {
+          protocols_and_count[protocol]++;
+        } else {
+          protocols_and_count[protocol] = 1;
+        }
+      } catch (e) {
+        // Not a valid URL. Skip over it
+        continue;
+      }
+    }
+
+    return protocols_and_count;
+  })(),
   // Find first child of <head>
   // Whether the first child of <head> is a Google Fonts <link>
   '06.47': (() => {
@@ -597,11 +624,11 @@ return JSON.stringify({
     const iframes_using_loading = [
       ...document.querySelectorAll("iframe[loading]"),
     ];
-  
+
     /** @type {ParseNodeOptions} */
     return {
       iframes: parseNodes(iframes),
-  
+
       loading_values: iframes_using_loading.map((iframe) => {
         const value = iframe.getAttribute("loading") || "";
         return value.toLocaleLowerCase().replace(/\s+/gm, " ").trim();

--- a/custom_metrics/metric-summary.md
+++ b/custom_metrics/metric-summary.md
@@ -219,6 +219,21 @@ Example response:
 }
 ```
 
+## link_protocols_used
+
+Lists all of the different protocols used in `<a href>` elements, along with their frequency
+
+Example response:
+
+```json
+{
+  "https": 2,
+  "http": 1,
+  "tel": 1,
+  "javascript": 1
+}
+```
+
 ## 06.47
 Detects if the first child of `<head>` is a Google Fonts `<link>`. `1` if true, `0` if false.
 


### PR DESCRIPTION
Progress on https://github.com/HTTPArchive/almanac.httparchive.org/issues/2151

This PR adds one new metric: `link_protocols_used`.

It's purpose is to list all the different types of protocols used in links on the page (sms, tel, https, ...)

It has been tested on a [custom page](https://output.jsbin.com/vafomucutu/1) and amazon which has a slew of links. Everything works as expected.

[Amazon.com](https://www.webpagetest.org/custom_metrics.php?test=210627_AiDcA0_21f55b07202f0919c68f5da4a8afcfff&run=1&cached=0)

[Custom page](https://www.webpagetest.org/custom_metrics.php?test=210627_BiDcNH_445e26032bcf071fe5eff777839660b5&run=1&cached=0)