### PR TITLE
Updated Images custom metric to use IntersectionObserver

### DIFF
--- a/custom_metrics/Images.js
+++ b/custom_metrics/Images.js
@@ -54,7 +54,10 @@ return new Promise((resolve) => {
 
   const imgs = wptImages(window);
 
-  for (let i = 0; i < imgs.length; i++) {
-    observer.observe(imgs[i]);
+  if (imgs.length == 0) {
+    return resolve([]);
+  }
+  for (let img of imgs) {
+    observer.observe(img);
   }
 });


### PR DESCRIPTION
Updated the Images custom metric `inViewport` property to use InteresctionObserver to improve reliability and support for:
- RTL languages
- Scrollable elements (such as carousels)

Inspired by: https://github.com/WPO-Foundation/webpagetest-docs/pull/36

Using IntersectionObserver adds some more complexity because of its async nature, however I tried to keep the custom metric as similar to its previous implementation as possible.

**Sample WPT**
https://webpagetest.org/custom_metrics.php?test=210716_AiDc99_be18dd00ed31c02ef0277471152b0fa8&run=1&cached=0

```
[
  {
    "url": "https://placekitten.com/304/304",
    "width": 304,
    "height": 304,
    "naturalWidth": 304,
    "naturalHeight": 304,
    "loading": "lazy",
    "decoding": null,
    "inViewport": true
  },
  {
    "url": "https://placekitten.com/305/305",
    "width": 305,
    "height": 305,
    "naturalWidth": 0,
    "naturalHeight": 0,
    "loading": "lazy",
    "decoding": null,
    "inViewport": false
  }
]
```