### PR TITLE
New metric to detect service workers in pwa.js

### DIFF
--- a/custom_metrics/pwa.js
+++ b/custom_metrics/pwa.js
@@ -1,13 +1,13 @@
 //[pwa]
 const response_bodies = $WPT_BODIES;
 const requests = $WPT_REQUESTS;
-const serviceWorkerRegistrationStrictPattern = /navigator\.serviceWorker\.register\(['"]([^"']+)/m;
+const serviceWorkerStrictRegistrationPattern = /navigator\.serviceWorker\.register\(['"]([^"']+)/m;
 
 const serviceWorkerURLs = response_bodies.filter(har => {
-  return serviceWorkerRegistrationStrictPattern.test(har.response_body);
+  return serviceWorkerStrictRegistrationPattern.test(har.response_body);
 }).map(har => {
   const base = new URL(location.href).origin;
-  const serviceWorkerPath = har.response_body.match(serviceWorkerRegistrationStrictPattern)[1];
+  const serviceWorkerPath = har.response_body.match(serviceWorkerStrictRegistrationPattern)[1];
   return new URL(serviceWorkerPath, base).href;
 }).reduce((set, url) => {
   set.add(url);
@@ -80,10 +80,10 @@ function getInfoForPattern(regexPattern, extractMatchingGroupOnly) {
   });
 }
 
-// Unlike serviceWorkerRegistrationStrictPattern that only matches SW registration scripts that contain URLs,
-// serviceWorkerRegistrationLaxPattern matches any call to the SW registration script (e.g. passing a variable, etc).
-const serviceWorkerRegistrationLaxPattern = /navigator\.serviceWorker\.register\(([^)]*)\)/g;
-const serviceWorkerInfo = getInfoForPattern(serviceWorkerRegistrationLaxPattern, true);
+// Unlike serviceWorkerStrictRegistrationPattern that only matches SW registration scripts that contain URLs,
+// serviceWorkerLaxRegistrationPattern matches any call to the SW registration script (e.g. passing a variable, etc).
+const serviceWorkerLaxRegistrationPattern = /navigator\.serviceWorker\.register\(([^)]*)\)/g;
+const serviceWorkerInfo = getInfoForPattern(serviceWorkerLaxRegistrationPattern, true);
 
 const workboxPattern = /(?:workbox:[a-z\-]+:[\d.]+|workbox\.[a-zA-Z]+\.?[a-zA-Z]*)/g;
 const workboxInfo = getInfoForPattern(workboxPattern);

--- a/custom_metrics/pwa.js
+++ b/custom_metrics/pwa.js
@@ -112,6 +112,24 @@ const windowEventListenersInfo = getInfoForPattern(windowEventListenersPattern, 
 const windowPropertiesPattern = /\.on(appinstalled|beforeinstallprompt)\s*=/g;
 const windowPropertiesInfo = getInfoForPattern(windowPropertiesPattern, true);
 
+// the sw heuristics returns true if a strong service worker indicator (serviceWorkers) exists, or if at least two weak indicators are present.
+function calculateServiceWorkerHeuristic() {
+  return !isObjectKeyEmpty(serviceWorkers) || containsEnoughWeakMethods();
+}
+
+// returns true if the number of "weak" methods to identify service workers is >= 2.
+function containsEnoughWeakMethods() {
+
+  var weakMethodCount = 0;
+
+  weakMethodCount+= isObjectKeyEmpty(serviceWorkerRegistrationInfo) ? 0 : 1;
+  weakMethodCount+= isObjectKeyEmpty(workboxInfo) ? 0 : 1;
+  weakMethodCount+= isObjectKeyEmpty(swEventListenersInfo) ? 0 : 1;
+  weakMethodCount+= isObjectKeyEmpty(swMethodsInfo) ? 0 : 1;
+
+  return weakMethodCount >= 2;
+}
+
 function isObjectKeyEmpty(field) {
   return field == null || field.length == 0;
 }
@@ -131,5 +149,5 @@ return {
   windowPropertiesInfo: Object.fromEntries(windowPropertiesInfo),
   serviceWorkerRegistrationInfo: Object.fromEntries(serviceWorkerRegistrationInfo),
   //Experimental field: Heuristic to detect if a site has a service worker even if the 'serviceWorkers' field is empty (false positives).
-  serviceWorkerHeuristic: !isObjectKeyEmpty(serviceWorkers) || !isObjectKeyEmpty(serviceWorkerRegistrationInfo) || !isObjectKeyEmpty(workboxInfo) || !isObjectKeyEmpty(swEventListenersInfo) || !isObjectKeyEmpty(swMethodsInfo)
+  serviceWorkerHeuristic: calculateServiceWorkerHeuristic()
 };

--- a/custom_metrics/pwa.js
+++ b/custom_metrics/pwa.js
@@ -83,7 +83,7 @@ function getInfoForPattern(regexPattern, extractMatchingGroupOnly) {
 // Unlike serviceWorkerStrictRegistrationPattern that only matches SW registration scripts that contain URLs,
 // serviceWorkerLaxRegistrationPattern matches any call to the SW registration script (e.g. passing a variable, etc).
 const serviceWorkerLaxRegistrationPattern = /navigator\.serviceWorker\.register\(([^)]*)\)/g;
-const serviceWorkerInfo = getInfoForPattern(serviceWorkerLaxRegistrationPattern, true);
+const serviceWorkerRegistrationInfo = getInfoForPattern(serviceWorkerLaxRegistrationPattern, true);
 
 const workboxPattern = /(?:workbox:[a-z\-]+:[\d.]+|workbox\.[a-zA-Z]+\.?[a-zA-Z]*)/g;
 const workboxInfo = getInfoForPattern(workboxPattern);
@@ -129,7 +129,7 @@ return {
   swRegistrationPropertiesInfo: Object.fromEntries(swRegistrationPropertiesInfo),
   windowEventListenersInfo: Object.fromEntries(windowEventListenersInfo),
   windowPropertiesInfo: Object.fromEntries(windowPropertiesInfo),
-  serviceWorkerInfo: Object.fromEntries(serviceWorkerInfo),
+  serviceWorkerRegistrationInfo: Object.fromEntries(serviceWorkerRegistrationInfo),
   //Experimental field: Heuristic to detect if a site has a service worker even if the 'serviceWorkers' field is empty (false positives).
-  serviceWorkerHeuristic: !isObjectKeyEmpty(serviceWorkers) || !isObjectKeyEmpty(serviceWorkerInfo) || !isObjectKeyEmpty(workboxInfo) || !isObjectKeyEmpty(swEventListenersInfo) || !isObjectKeyEmpty(swMethodsInfo)
+  serviceWorkerHeuristic: !isObjectKeyEmpty(serviceWorkers) || !isObjectKeyEmpty(serviceWorkerRegistrationInfo) || !isObjectKeyEmpty(workboxInfo) || !isObjectKeyEmpty(swEventListenersInfo) || !isObjectKeyEmpty(swMethodsInfo)
 };


### PR DESCRIPTION
This PR contains the following changes to pwa.js:

- Added  a new field `serviceWorkerInfo` that uses a new regular expression to detect service worker registrations, that  matches the cases that the original one was ignoring: for example relative paths and variables used as the service worker URL. [Here is](https://webpagetest.org/result/210802_BiDcAB_61a77c283d1cdc85b764aa97658e7a2d/?f=json) an example test for mobile.twtiter.com, which was originally ignored and now it's found under `serviceWorkerInfo`.
- Added the new variable `serviceWorkerInfo` to the conditions for the `serviceWorkerHeuristic`. Ideally, the number of detected service workers should approximate more closely to `serviceWorkerHeuristic`.
- Added the `fetch` event listener to `swEventListenersInfo`. We initially removed the "fetch" keyword to avoid false positives (since the event can be used in pages too), but we recently realized that the pattern: `addEventListener("fetch", ...)`, can only happen inside a service worker, so it makes sense to add it, at least there.

We should discuss if the original `serviceWorkers` continues making sense or not. Maybe after seeing the data, we'll have a better idea.

Unfortunately, these changes won't make it for the 2021 version of Web Almanac, but we thought about leaving them prepared for 2021.

cc // @tunetheweb @rviscomi 