### PR TITLE
Suggestions for 'prefersColorScheme' custom metric

### DIFF
--- a/custom_metrics/css.js
+++ b/custom_metrics/css.js
@@ -2,7 +2,7 @@
 // Uncomment the previous line for testing on webpagetest.org
 
 const PREFERS_COLOR_SCHEME_REGEXP =
-  /@media\s+\(\s*prefers-color-scheme\s*:\s*(?:dark|light)\s*\)\s*\{[^\}]*\}/gms;
+  /(@media\s*\(\s*prefers-color-scheme\s*:\s*(?:dark|light)\s*\)\s*\{[^\}]*\}|window.matchMedia\([\'"]\s*\(prefers-color-scheme\s*:\s*(?:dark|light)\)[\'"])/gms;
 
 const bodies = $WPT_BODIES;
 
@@ -39,20 +39,15 @@ return JSON.stringify({
     return usedLibraries;
   })(),
   // Checks in two passes:
-  // 1. The response body of same- and cross-origin stylesheets.
+  // 1. The response bodies.
   // 2. The `link[media]` attribute of conditionally loaded stylesheets in the
   //    ternary expression if step 1. returns `false`.
   prefersColorScheme:
-    // For all stylesheets…
-    // …check if the `prefers-color-scheme` RegExp matches…
-    // If even just one of the stylesheets matches, return `true`.
     bodies.some((request) => {
-      return (
-        request.type === 'Stylesheet' &&
-        PREFERS_COLOR_SCHEME_REGEXP.test(request.response_body || '')
+      return (PREFERS_COLOR_SCHEME_REGEXP.test(request.response_body || '')
       );
     }) ||
-    // If none of the stylesheets match, alternatively check if any of the
+    // If none of the response bodies match, alternatively check if any of the
     // stylesheet `link`s load conditionally based on `prefers-color-scheme`.
     document.querySelectorAll(
       'link[rel="stylesheet"][media*="prefers-color-scheme"]',

--- a/custom_metrics/css.js
+++ b/custom_metrics/css.js
@@ -2,7 +2,7 @@
 // Uncomment the previous line for testing on webpagetest.org
 
 const PREFERS_COLOR_SCHEME_REGEXP =
-  /(@media\s*\(\s*prefers-color-scheme\s*:\s*(?:dark|light)\s*\)\s*\{[^\}]*\}|window.matchMedia\([\'"]\s*\(prefers-color-scheme\s*:\s*(?:dark|light)\)[\'"])/gms;
+  /(@media\s*\(\s*prefers-color-scheme\s*:\s*(?:dark|light)\s*\)\s*\{[^\}]*\}|window.matchMedia\([\'"]\s*\(prefers-color-scheme\s*:\s*(?:dark|light)\)[\'"])\)/gms;
 
 const bodies = $WPT_BODIES;
 

--- a/custom_metrics/css.js
+++ b/custom_metrics/css.js
@@ -2,7 +2,6 @@
 // Uncomment the previous line for testing on webpagetest.org
 
 const PREFERS_COLOR_SCHEME_REGEXP =
-  /(@media\s*\(\s*prefers-color-scheme\s*:\s*(?:dark|light)\s*\)\s*\{[^\}]*\}|window.matchMedia\([\'"]\s*\(prefers-color-scheme\s*:\s*(?:dark|light)\)[\'"])\)/gms;
   /(?:@media\s*\(\s*prefers-color-scheme\s*:\s*(?:dark|light)\s*\)\s*\{[^\}]*\}|matchMedia\s*\(\s*['"]\s*\(\s*prefers-color-scheme\s*:\s*(?:dark|light)\s*\)\s*['"]\s*\))/gms;
 
 const bodies = $WPT_BODIES;

--- a/custom_metrics/css.js
+++ b/custom_metrics/css.js
@@ -3,6 +3,7 @@
 
 const PREFERS_COLOR_SCHEME_REGEXP =
   /(@media\s*\(\s*prefers-color-scheme\s*:\s*(?:dark|light)\s*\)\s*\{[^\}]*\}|window.matchMedia\([\'"]\s*\(prefers-color-scheme\s*:\s*(?:dark|light)\)[\'"])\)/gms;
+  /(?:@media\s*\(\s*prefers-color-scheme\s*:\s*(?:dark|light)\s*\)\s*\{[^\}]*\}|matchMedia\s*\(\s*['"]\s*\(\s*prefers-color-scheme\s*:\s*(?:dark|light)\s*\)\s*['"]\s*\))/gms;
 
 const bodies = $WPT_BODIES;
 
@@ -44,7 +45,9 @@ return JSON.stringify({
   //    ternary expression if step 1. returns `false`.
   prefersColorScheme:
     bodies.some((request) => {
-      return (PREFERS_COLOR_SCHEME_REGEXP.test(request.response_body || '')
+      return (
+        (request.type === 'Stylesheet' || request.type === 'Script') &&
+        PREFERS_COLOR_SCHEME_REGEXP.test(request.response_body || '')
       );
     }) ||
     // If none of the response bodies match, alternatively check if any of the


### PR DESCRIPTION
Thanks again @tomayac for working on this script.

I started to analyze how sites have implemented a dark theme and decided to use the custom metric to see if worked. The sites I'm currently analyzing are: https://mobile.twitter.com, https://web.whatsapp.com, https://www.github.com, https://www.youtube.com and https://pwa.zdf.com.

Based on what I could see there, I'm suggesting the following changes:

- Allowing for zero (instead of one) or more spaces between `@media` and the parenthesis.
- Including a regex for `window.matchMedia()` as some sites seem to be checking `prefers-color-scheme` via JS.
- Checking all the response bodies, instead of just the stylesheets, as developers tend to add the dark CSS themes directly in the HTML or JS.

This last one is controversial, and I guess you might have already thought about it. I recall you mentioned that libraries like Facebook use it for tracking purposes. There will be also other false positives, like Web.dev ([test](https://webpagetest.org/result/210903_AiDcSZ_029aff9a388d93c118cf81bed8740990/?f=json)), which doesn't provide dark mode, but contains articles that talk about how to implement it. In any case, it seems like the false negatives for only checking CSS files could be higher. If you disagree, we can go back to the previous one.

Another thing we can do is to create a separate metric: `prefersColorSchemeLax`, which parses all the files. Then we can compare the delta, and if there are some libraries like Facebook, we can crate an exclusion list.

#### Additional tests:

- [Twitter Test](https://webpagetest.org/result/210903_AiDcPR_3cad749b14b7ae09dd2055db29f64250/?f=json): Used to return `false` and now returns `true`. They use the `prefers-color-scheme` directly in the HTML.
- [Github Test](https://webpagetest.org/result/210903_AiDc79_17cba441b483500447570950063dab3e/?f=json). Used to return `@media(prefers-color-scheme: dark)` because they have no space between `@media` and the parenthesis: `@media(prefers-color-scheme: dark)`. Now returns true.
- [Youtube Test](https://webpagetest.org/result/210904_BiDcNE_1b306655867ca2a90a6cc72ce41b52be/?f=json) uses `window.matchMedia()`, so it returns `true`.

I hope this helps.

cc // @andreban @una @beverloo @rviscomi 