### PR TITLE
Added form markup custom metric

### DIFF
--- a/custom_metrics/markup.js
+++ b/custom_metrics/markup.js
@@ -110,48 +110,57 @@ try { // whole process is placed in a try/catch so we can log uncaught errors
     // forms
     'form': (() => {   
       try {   
-        let result = {target: {}, method: {}, inputs: []};
+        let result = { target: {}, method: {}, elements: [] };
 
-        var nodes = [...document.querySelectorAll('form')];
-
+        var nodes = [...document.querySelectorAll("form")];
+        
         result.total = nodes.length;
-
+        
         nodes.forEach((n) => {
           let target = n.getAttribute("target");
-
+        
           if (target) {
-              if (result.target[target])
-                result.target[target]++;
-              else 
-                result.target[target] = 1;
+            if (result.target[target]) result.target[target]++;
+            else result.target[target] = 1;
           }
-
+        
           let method = n.getAttribute("method");
-
+        
           if (method) {
-              if (result.method[method])
-                result.method[method]++;
-              else 
-                result.method[method] = 1;
+            if (result.method[method]) result.method[method]++;
+            else result.method[method] = 1;
           }
-          
-          var inputs = {types: {}}
-
-          var elements = [...n.querySelectorAll('input')];
-
+        
+          var inputs = { tagNames: {}, types: {} };
+        
+          var elements = [
+            ...n.querySelectorAll(
+              "input, label, select, textarea, button, fieldset, legend, datalist, output, option, optgroup"
+            ),
+          ];
+        
           elements.forEach((m) => {
+            let tagName = m.tagName.toLowerCase();
+            
+            if (inputs.tagNames[tagName]) {
+              inputs.tagNames[tagName]++;
+            } else {
+              inputs.tagNames[tagName] = 1;
+            }
+            
             let type = m.getAttribute("type");
-
+        
             if (type) {
-                if (inputs.types[type])
-                  inputs.types[type]++;
-                else 
-                  inputs.types[type] = 1;
+              if (inputs.types[type]) {
+                inputs.types[type]++;
+              } else {
+                inputs.types[type] = 1;
+              }
             }
           });
-
-          result.inputs.push({...inputs, total: elements.length});
-        });
+        
+          result.elements.push({ ...inputs, total: elements.length });
+        });              
 
         return result;
       }

--- a/custom_metrics/markup.js
+++ b/custom_metrics/markup.js
@@ -107,6 +107,59 @@ try { // whole process is placed in a try/catch so we can log uncaught errors
       }
     })(),
 
+    // forms
+    'form': (() => {   
+      try {   
+        let result = {target: {}, method: {}, inputs: []};
+
+        var nodes = [...document.querySelectorAll('form')];
+
+        result.total = nodes.length;
+
+        nodes.forEach((n) => {
+          let target = n.getAttribute("target");
+
+          if (target) {
+              if (result.target[target])
+                result.target[target]++;
+              else 
+                result.target[target] = 1;
+          }
+
+          let method = n.getAttribute("method");
+
+          if (method) {
+              if (result.method[method])
+                result.method[method]++;
+              else 
+                result.method[method] = 1;
+          }
+          
+          var inputs = {types: {}}
+
+          var elements = [...n.querySelectorAll('input')];
+
+          elements.forEach((m) => {
+            let type = m.getAttribute("type");
+
+            if (type) {
+                if (inputs.types[type])
+                  inputs.types[type]++;
+                else 
+                  inputs.types[type] = 1;
+            }
+          });
+
+          result.inputs.push({...inputs, total: elements.length});
+        });
+
+        return result;
+      }
+      catch(e) {
+        return logError("form", e);
+      }
+    })(),
+
     // dir attributes
     // Used by Markup, 2019/09_28
     'dirs': (() => {   


### PR DESCRIPTION
Updated the `markup` custom metric to include `form` property containing the number of `form` elements in the page, `target` and `method` attributes and elements within each form.

Sample WPT
https://webpagetest.org/custom_metrics.php?test=211011_AiDc0S_19c860e38dfd192c218c189e3df59af2&run=1&cached=0

```
...
{
  "form": {
    "target": { "_blank": 2 },
    "method": { "post": 1 },
    "elements": [
      {
        "tagNames": { "fieldset": 1, "legend": 1, "input": 3 },
        "types": { "text": 2, "submit": 1 },
        "total": 5
      },
      {
        "tagNames": { "input": 2, "button": 1 },
        "types": { "submit": 1 },
        "total": 3
      }
    ],
    "total": 2
  }
}
...
```